### PR TITLE
Use general vm specification hashes

### DIFF
--- a/.github/workflows/plan_testing.yaml
+++ b/.github/workflows/plan_testing.yaml
@@ -55,14 +55,17 @@ jobs:
             "os": "ubuntu",
             "os_version": "2404",
             "os_arch": "x86_64",
-            "architecture": "singular",
-            "agents": 1,
-            "primary_cpus": 2,
-            "primary_mem_mb": 4096,
-            "primary_disk_gb": 5,
-            "agent_cpus": 1,
-            "agent_mem_mb": 512,
-            "agent_disk_gb": 5
+            "vms": [
+              {
+                "role": "primary",
+                "cpus": 2,
+                "mem_mb": 4096,
+                "disk_gb": 5
+              },
+              {
+                "role": "agent"
+              }
+            ]
           }
           EOF
       - name: Run standup_cluster plan

--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -16,6 +16,10 @@ jobs:
         ruby-version:
           - '3.2'
           - '3.3'
+# Not testing 3.4 yet; bundler fails here:
+# bundler: failed to load command: bolt (/home/runner/work/kvm_automation_tooling/kvm_automation_tooling/vendor/bundle/ruby/3.4.0/bin/bolt)
+# /home/runner/work/kvm_automation_tooling/kvm_automation_tooling/vendor/bundle/ruby/3.4.0/gems/puppet-8.10.0/lib/puppet/feature/base.rb:21:in '<top (required)>': Cannot determine basic system flavour (Puppet::Error)
+#          - '3.4'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/functions/fill_vm_spec.pp
+++ b/functions/fill_vm_spec.pp
@@ -1,0 +1,8 @@
+# Expand a VM specification hash by filling in defaults from a given
+# Hash.
+function kvm_automation_tooling::fill_vm_spec(
+  Kvm_automation_tooling::Vm_spec $vm_spec,
+  Kvm_automation_tooling::Vm_spec $defaults,
+) >> Kvm_automation_tooling::Vm_spec {
+  $defaults + $vm_spec
+}

--- a/functions/generate_terraform_vm_spec_set.pp
+++ b/functions/generate_terraform_vm_spec_set.pp
@@ -1,0 +1,46 @@
+# Expands the compact vm specification used by the plan into a
+# map of terraform objects (hashes) keyed by unique hostname,
+# that map one to one with each vm we want terraform to create.
+#
+# See the spec/functions/generate_terraform_vm_spec_set_spec.rb for
+# a concrete example.
+#
+# Missing values for cpus, mem_mb, disk_gb and cpu_mode are provided
+# by terraform modules/vm defaults.
+#
+# @param $cluster_id The unique identifier for the cluster.
+# @param $vm_specs The compact vm specification used by the plan.
+# @param $image_results The results of each manage_base_image_volume
+#   plan run for each platform in the specs.
+function kvm_automation_tooling::generate_terraform_vm_spec_set(
+  String $cluster_id,
+  Array[Kvm_automation_tooling::Vm_spec] $vm_specs,
+  Array[Hash] $image_results,
+) >> Hash[String, Hash] {
+  $vm_specs.reduce({}) |$map, $spec| {
+
+    $platform = kvm_automation_tooling::platform($spec)
+    $count = $spec['count'] =~ Undef ? {
+      true    => 1,
+      default => $spec['count'],
+    }
+    $image_result = $image_results.filter |$i| {
+      $i['platform'] == $platform
+    }[0]
+
+    $common = $spec.filter |$k, $_v| {
+      ['cpus', 'mem_mb', 'disk_gb', 'cpu_mode'].any |$i| {
+        $k == $i
+      }
+    } + {
+      'base_volume_name' => $image_result['base_volume_name'],
+      'pool_name'        => $image_result['pool_name'],
+    }
+
+    $map + Integer[1, $count].reduce({}) |$m, $i| {
+      $m + {
+        "${cluster_id}-${spec['role']}-${i}" => $common
+      }
+    }
+  }
+}

--- a/functions/platform.pp
+++ b/functions/platform.pp
@@ -1,10 +1,22 @@
 # Generic function to produce a cononical descriptive platform string from
 # a set of os, version and cpu arch values.
 function kvm_automation_tooling::platform(
-  Kvm_automation_tooling::Operating_system $os,
-  Kvm_automation_tooling::Version $version,
-  Kvm_automation_tooling::Os_arch $arch,
+  Variant[
+    Struct[{
+      os         => Kvm_automation_tooling::Operating_system,
+      os_version => Kvm_automation_tooling::Version,
+      os_arch    => Kvm_automation_tooling::Os_arch,
+    }],
+    Kvm_automation_tooling::Vm_spec
+  ] $vm_spec,
 ) {
+  $os = $vm_spec['os']
+  $version = $vm_spec['os_version']
+  $arch = $vm_spec['os_arch']
+  if [$os, $version, $arch].any |$v| {$v =~ Undef } {
+    fail("An os, os_version, and os_arch must be set in the vm_spec. Received: ${vm_spec}")
+  }
+
   case $os {
     'ubuntu': {
       $_version = kvm_automation_tooling::get_normalized_ubuntu_version($version)

--- a/plans/dev/prep_vm_for_module_testing.pp
+++ b/plans/dev/prep_vm_for_module_testing.pp
@@ -129,14 +129,17 @@ plan kvm_automation_tooling::dev::prep_vm_for_module_testing(
       "os": "ubuntu",
       "os_version": "2404",
       "os_arch": "x86_64",
-      "architecture": "singular",
-      "agents": 1,
-      "primary_cpus": 2,
-      "primary_mem_mb": 4096,
-      "primary_disk_gb": 5,
-      "agent_cpus": 1,
-      "agent_mem_mb": 512,
-      "agent_disk_gb": 5
+      "vms": [
+        {
+          "role": "primary",
+          "cpus": 2,
+          "mem_mb": 4096,
+          "disk_gb": 5
+        },
+        {
+          "role": "agent"
+        }
+      ]
     }
     EOF
     bundle exec bolt plan run kvm_automation_tooling::standup_cluster --params @standup_cluster_params.json

--- a/plans/standup_cluster.pp
+++ b/plans/standup_cluster.pp
@@ -16,22 +16,23 @@
 #   the cluster.
 # @param network_addresses The network address range to use for the
 #   cluster. This should be a /24 CIDR block.
-# @param primary The number of primary vms to stand up in the cluster
-#   (0 or 1).
-# @param primary_cpus The number of CPUs to allocate to the primary vm.
-# @param primary_mem_mb The amount of memory in MB to allocate to the
-#   primary vm.
-# @param primary_disk_gb The amount of disk space in GB to allocate to
-#   the primary vm.
-# @param agents The number of Puppet agent vms to stand up in the
-#   cluster.
-# @param agent_cpus The number of CPUs to allocate to each agent vm.
-# @param agent_mem_mb The amount of memory in MB to allocate to each
-#   agent vm.
-# @param agent_disk_gb The amount of disk space in GB to allocate to
-#   each agent vm.
-# @param cpu_mode The CPU mode to use for the vm domains. Set this to
-#   'host-passthrough' to enable nested virtualization.
+# @param vms An array of VM specifications for the cluster. Example:
+#     [
+#       {
+#         'role' => 'primary',
+#         'cpus": 8,
+#         'mem_mb': 8192,
+#         'disk_gb': 20,
+#       },
+#       {
+#         'role' => 'agent',
+#         'count' => 3,
+#       },
+#     ]
+#   The os, os_version and os_arch keys are provided by the top
+#   level plan parameters unless overridden in a specific spec hash.
+#   The count key is optional and defaults to 1.
+#   (See the Kvm_automation_tooling::Vm_spec type for details.)
 # @param image_download_dir The directory where base os images are
 #   downloaded to. This should be an absolute path.
 # @param terraform_state_dir The directory where terraform state files,
@@ -47,8 +48,10 @@
 # @param ssh_private_key_path The path to the private key to use for
 #   ssh access to the vms. (This will be set in the generated inventory
 #   file.)
-# @param user_password The password to set for the login user on the vms.
-#   This is optional and should only be used for debugging.
+# @param user_password The password to set for the login user on the
+#   vms. This is optional and should only be used for debugging.
+# @param install_openvox Whether to install OpenVox Puppet on the
+#   vms in the cluster.
 plan kvm_automation_tooling::standup_cluster(
   String $cluster_name,
   Kvm_automation_tooling::Architecture $architecture = 'singular',
@@ -56,15 +59,7 @@ plan kvm_automation_tooling::standup_cluster(
   Kvm_automation_tooling::Version $os_version,
   Kvm_automation_tooling::Os_arch $os_arch,
   Stdlib::Ip::Address::V4::CIDR $network_addresses,
-  Integer[0,1] $primary = 1,
-  Integer $primary_cpus = 4,
-  Integer $primary_mem_mb = 8192,
-  Integer $primary_disk_gb = 20,
-  Integer $agents = 1,
-  Integer $agent_cpus = 1,
-  Integer $agent_mem_mb = 512,
-  Integer $agent_disk_gb = 10,
-  Optional[String] $cpu_mode = undef,
+  Array[Kvm_automation_tooling::Vm_spec,1] $vms,
   String $image_download_dir = "${system::env('HOME')}/images",
   String $terraform_state_dir = 'kvm_automation_tooling/../terraform/instances',
   String $user = system::env('USER'),
@@ -74,44 +69,54 @@ plan kvm_automation_tooling::standup_cluster(
   Boolean $install_openvox = true,
 ) {
   $terraform_dir = './terraform'
-  $platform = kvm_automation_tooling::platform($os, $os_version, $os_arch)
-  $cluster_id = "${cluster_name}-${architecture}-${platform}"
+
+  $vm_specs = $vms.map |$vm_spec| {
+    kvm_automation_tooling::fill_vm_spec($vm_spec, {
+      'role'       => 'defaults',
+      'os'         => $os,
+      'os_version' => $os_version,
+      'os_arch'    => $os_arch,
+    })
+  }
+  $roles = $vms.map |$s| { $s['role'] }.unique()
+
+  $cluster_platform = kvm_automation_tooling::platform({
+    'os'         => $os,
+    'os_version' => $os_version,
+    'os_arch'    => $os_arch,
+  })
+  $vm_platforms = $vm_specs.map |$vm_spec| {
+    kvm_automation_tooling::platform($vm_spec)
+  }.unique()
+
+  $cluster_id = "${cluster_name}-${architecture}-${cluster_platform}"
   $domain_name = "${cluster_id}.vm"
-  $primary_hostname = "${cluster_id}-primary"
-  $agent_hostnames = $agents.map |$i| { "${cluster_id}-agent-${i}" }
   $_terraform_state_dir = find_file($terraform_state_dir)
   $tfvars_file = "${_terraform_state_dir}/${cluster_id}.tfvars.json"
   $tfstate_file_name = "${cluster_id}.tfstate"
   $tfstate_file = "${_terraform_state_dir}/${tfstate_file_name}"
   $inventory_file = "${_terraform_state_dir}/inventory.${cluster_id}.yaml"
 
-  # Ensure base image volume is present and a platform image pool exists.
-  $image_results = run_plan('kvm_automation_tooling::subplans::manage_base_image_volume',
-    'platform' => $platform,
-    'image_download_dir' => $image_download_dir,
-  )
+  # Ensure base image volumes are present and a platform image pools
+  # exist.
+  $image_results = parallelize($vm_platforms) |$p| {
+    run_plan(
+      'kvm_automation_tooling::subplans::manage_base_image_volume',
+      'platform' => $p,
+      'image_download_dir' => $image_download_dir,
+    )
+  }
 
   # Write cluster specific tfvars.json file to a separate directory to
   # keep different cluster instances separated.
   file::write($tfvars_file, stdlib::to_json({
-    # TODO: this list was generated by copilot and needs to be reviewed.
     'cluster_id'          => $cluster_id,
-    'base_volume_name'    => $image_results['base_volume_name'],
-    'pool_name'           => $image_results['pool_name'],
     'network_addresses'   => $network_addresses,
     'domain_name'         => $domain_name,
     'user_name'           => $user,
     'ssh_public_key_path' => $ssh_public_key_path,
     'user_password'       => $user_password,
-    'primary_count'       => $primary,
-    'primary_cpus'        => $primary_cpus,
-    'primary_memory'      => $primary_mem_mb,
-    'primary_disk_size'   => $primary_disk_gb,
-    'agent_count'         => $agents,
-    'agent_cpus'          => $agent_cpus,
-    'agent_memory'        => $agent_mem_mb,
-    'agent_disk_size'     => $agent_disk_gb,
-    'cpu_mode'            => $cpu_mode,
+    'vm_specs'            => kvm_automation_tooling::generate_terraform_vm_spec_set($cluster_id, $vm_specs, $image_results),
   }))
 
   # Ensure terraform dependencies are installed.
@@ -124,7 +129,12 @@ plan kvm_automation_tooling::standup_cluster(
     'state'    => $tfstate_file,
     'return_output' => true,
   )
-  out::message($apply_result)
+  $ip_addresses = $apply_result.dig('vm_ip_addresses', 'value')
+  if $ip_addresses =~ Undef {
+    log::warn("Terraform apply did not return an ip address list:\n${apply_result}")
+  } else {
+    out::message("VM IP addresses: ${stdlib::to_json_pretty($ip_addresses)}")
+  }
 
   # Generate an inventory file for the cluster.
   file::write($inventory_file, epp('kvm_automation_tooling/inventory.yaml.epp', {
@@ -135,15 +145,16 @@ plan kvm_automation_tooling::standup_cluster(
     'domain_name'       => $domain_name,
   }))
 
-  $primary_target = kvm_automation_tooling::resolve_terraform_targets($inventory_file, 'primary')[0]
-  out::message("Primary target: ${primary_target}")
+  $target_map = $roles.reduce({}) |$map, $role| {
+    $targets = kvm_automation_tooling::resolve_terraform_targets($inventory_file, $role)
+    out::message("${capitalize($role)} targets: ${stdlib::to_json_pretty($targets)}")
+    $map + { $role => $targets }
+  }
 
-  $agent_targets = kvm_automation_tooling::resolve_terraform_targets($inventory_file, 'agent')
-  out::message("Agent targets: ${agent_targets}")
-
-  $all_targets = [$primary_target] + $agent_targets
+  $all_targets = $target_map.values().flatten()
 
   if $install_openvox {
+    $primary_target = $target_map.dig('primary', 0)
     run_plan('kvm_automation_tooling::subplans::install_openvox',
       'targets' => $all_targets,
       'puppetserver_target' => $primary_target,

--- a/plans/standup_cluster.pp
+++ b/plans/standup_cluster.pp
@@ -7,15 +7,11 @@
 #   *os_version*, *os_arch* to obtain a reasonably unique id for the
 #   cluster. The *cluster_name* allows you to stand up more than one
 #   cluster of the same architecture and platform, for example.
-# @param architecture The Puppet services architecture of the cluster
-#   (see docs/ARCHITECTURE.md).
 # @param os The base operating system of the cluster.
 # @param os_version The version of the base operating system of the
 #   cluster.
 # @param os_arch The chip architecture of the base operating system of
 #   the cluster.
-# @param network_addresses The network address range to use for the
-#   cluster. This should be a /24 CIDR block.
 # @param vms An array of VM specifications for the cluster. Example:
 #     [
 #       {
@@ -33,6 +29,13 @@
 #   level plan parameters unless overridden in a specific spec hash.
 #   The count key is optional and defaults to 1.
 #   (See the Kvm_automation_tooling::Vm_spec type for details.)
+# @param network_addresses The network address range to use for the
+#   cluster. This should be a /24 CIDR block.
+# @param domain_name The domain name to use for the cluster. This is
+#   appended to the hostnames of the VMs in the cluster, and will
+#   resolve locally within the cluster.
+# @param architecture The Puppet services architecture of the cluster
+#   (see docs/ARCHITECTURE.md).
 # @param image_download_dir The directory where base os images are
 #   downloaded to. This should be an absolute path.
 # @param terraform_state_dir The directory where terraform state files,
@@ -54,12 +57,13 @@
 #   vms in the cluster.
 plan kvm_automation_tooling::standup_cluster(
   String $cluster_name,
-  Kvm_automation_tooling::Architecture $architecture = 'singular',
   Kvm_automation_tooling::Operating_system $os,
   Kvm_automation_tooling::Version $os_version,
   Kvm_automation_tooling::Os_arch $os_arch,
-  Stdlib::Ip::Address::V4::CIDR $network_addresses,
   Array[Kvm_automation_tooling::Vm_spec,1] $vms,
+  Stdlib::Ip::Address::V4::CIDR $network_addresses,
+  String $domain_name = 'vm',
+  Kvm_automation_tooling::Architecture $architecture = 'singular',
   String $image_download_dir = "${system::env('HOME')}/images",
   String $terraform_state_dir = 'kvm_automation_tooling/../terraform/instances',
   String $user = system::env('USER'),
@@ -90,7 +94,6 @@ plan kvm_automation_tooling::standup_cluster(
   }.unique()
 
   $cluster_id = "${cluster_name}-${architecture}-${cluster_platform}"
-  $domain_name = "${cluster_id}.vm"
   $_terraform_state_dir = find_file($terraform_state_dir)
   $tfvars_file = "${_terraform_state_dir}/${cluster_id}.tfvars.json"
   $tfstate_file_name = "${cluster_id}.tfstate"

--- a/plans/subplans/install_openvox.pp
+++ b/plans/subplans/install_openvox.pp
@@ -9,10 +9,11 @@
 # @param postgresql_target The target to install PostgreSQL on.
 plan kvm_automation_tooling::subplans::install_openvox(
   Array[Target] $targets,
-  Target $puppetserver_target,
-  Target $puppetdb_target,
-  Target $postgresql_target,
+  Optional[Target] $puppetserver_target,
+  Optional[Target] $puppetdb_target,
+  Optional[Target] $postgresql_target,
 ) {
   apply_prep($targets)
 
+  # TODO: Apply manifests to standup the server services.
 }

--- a/plans/subplans/manage_base_image_volume.pp
+++ b/plans/subplans/manage_base_image_volume.pp
@@ -23,6 +23,8 @@ plan kvm_automation_tooling::subplans::manage_base_image_volume(
 
   # Ensure platform image pool exists.
   $pool_name = "${platform}.pool"
+  # TODO: This should probably just be called 'pool_dir'. Or I should
+  #       elliminate the distinction between the two and drop '.pool'.
   $pool_path = $platform
   run_task('kvm_automation_tooling::create_libvirt_image_pool', 'localhost',
     'name' => $pool_name,
@@ -30,6 +32,7 @@ plan kvm_automation_tooling::subplans::manage_base_image_volume(
   )
 
   $result = {
+    'platform'         => $platform,
     'base_image_url'   => $base_image_url,
     'base_volume_name' => $base_image_name,
     'pool_name'        => $pool_name,

--- a/spec/fixtures/terraform/spec.tfstate
+++ b/spec/fixtures/terraform/spec.tfstate
@@ -4,20 +4,32 @@
   "serial": 261,
   "lineage": "a1bf6955-9c84-4a46-1211-0709a6e25cbe",
   "outputs": {
-    "agent_ip_addresses": {
-      "value": [
-        "192.168.100.163"
-      ],
+    "vm_ip_addresses": {
+      "value": {
+        "spec-singular-ubuntu-2404-amd64-agent-1": {
+          "ip_address": "192.168.100.37"
+        },
+        "spec-singular-ubuntu-2404-amd64-primary-1": {
+          "ip_address": "192.168.100.224"
+        }
+      },
       "type": [
-        "tuple",
-        [
-          "string"
-        ]
+        "object",
+        {
+          "spec-singular-ubuntu-2404-amd64-agent-1": [
+            "object",
+            {
+              "ip_address": "string"
+            }
+          ],
+          "spec-singular-ubuntu-2404-amd64-primary-1": [
+            "object",
+            {
+              "ip_address": "string"
+            }
+          ]
+        }
       ]
-    },
-    "primary_ip_address": {
-      "value": "192.168.100.158",
-      "type": "string"
     }
   },
   "resources": [
@@ -34,7 +46,7 @@
               "192.168.100.0/24"
             ],
             "autostart": true,
-            "bridge": "virbr2",
+            "bridge": "virbr1",
             "dhcp": [
               {
                 "enabled": true
@@ -50,7 +62,7 @@
               }
             ],
             "dnsmasq_options": [],
-            "domain": "spec-singular-ubuntu-2404-amd64.vm",
+            "domain": "vm",
             "id": "60fbc68c-bce3-416e-b94a-420021d56e95",
             "mode": "nat",
             "mtu": null,
@@ -64,7 +76,7 @@
       ]
     },
     {
-      "module": "module.agent[0]",
+      "module": "module.vmdomain[\"spec-singular-ubuntu-2404-amd64-agent-1\"]",
       "mode": "managed",
       "type": "libvirt_cloudinit_disk",
       "name": "commoninit",
@@ -73,9 +85,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "/var/lib/libvirt/images/ubuntu-2404-amd64/commoninit.iso.spec-singular-ubuntu-2404-amd64-agent-0;8b92042a-d478-4c91-8218-df23eb1bb96f",
-            "meta_data": "instance-id: i-69613321-19c1-10e7-6bf0-1dde0da8593c\nlocal-hostname: agent-0\n",
-            "name": "commoninit.iso.spec-singular-ubuntu-2404-amd64-agent-0",
+            "id": "/var/lib/libvirt/images/ubuntu-2404-amd64/commoninit.iso.spec-singular-ubuntu-2404-amd64-agent-1;0c6db798-6b66-4add-a8b6-875a061827de",
+            "meta_data": "instance-id: i-5d6ae91c-1361-0d87-3438-c4dfca5974c4\nlocal-hostname: spec-singular-ubuntu-2404-amd64-agent-1\n",
+            "name": "commoninit.iso.spec-singular-ubuntu-2404-amd64-agent-1",
             "network_config": "network:\n  version: 2\n  ethernets:\n    # The primary network interface. The id0 identifier is purely internal\n    # to cloud-init. The actual device name is matched by the match.name\n    # key, since the virtio network device name can vary, but should be\n    # some variation of ens[\\d] or enp[\\d]s[\\d]. (see\n    # https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/)\n    id0:\n      #\n      match:\n        name: en*\n      dhcp4: yes\n      nameservers:\n        addresses: [192.168.100.1]\n      routes:\n      - to: 0.0.0.0/0\n        via: 192.168.100.1\n",
             "pool": "ubuntu-2404-amd64.pool",
             "user_data": "#cloud-config\n# ^^^ warning, this magic comment is necessary for cloud-init to recognize and process this file...\n# https://cloudinit.readthedocs.io/en/latest/explanation/about-cloud-config.html#how-do-i-create-a-cloud-config-file\n#\n# Users and Groups Module\n# https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups\nusers:\n  - name: spec\n    ssh_authorized_keys:\n      - ssh key\n\n    sudo: [\"ALL=(ALL) NOPASSWD:ALL\"]\n    groups: sudo\n    shell: /bin/bash\n# Set Passwords Module\n# https://cloudinit.readthedocs.io/en/latest/reference/modules.html#set-passwords\n# Do not require password change on first login.\nchpasswd: { expire: False }\n# Package Update Upgrade Install Module\n# https://cloudinit.readthedocs.io/en/latest/reference/modules.html#package-update-upgrade-install\n# Ensure qemu agent is installed so that terraform-provider-libvirt can retrieve IP address.\npackages: qemu-guest-agent\n# https://cloudinit.readthedocs.io/en/latest/reference/modules.html#runcmd\nruncmd:\n  - [ systemctl, daemon-reload ]\n  - [ systemctl, enable, qemu-guest-agent.service ]\n  - [ systemctl, start, --no-block, qemu-guest-agent.service ]\n"
@@ -89,7 +101,7 @@
       ]
     },
     {
-      "module": "module.agent[0]",
+      "module": "module.vmdomain[\"spec-singular-ubuntu-2404-amd64-agent-1\"]",
       "mode": "managed",
       "type": "libvirt_domain",
       "name": "domain",
@@ -101,8 +113,8 @@
             "arch": "x86_64",
             "autostart": false,
             "boot_device": [],
-            "cloudinit": "/var/lib/libvirt/images/ubuntu-2404-amd64/commoninit.iso.spec-singular-ubuntu-2404-amd64-agent-0;8b92042a-d478-4c91-8218-df23eb1bb96f",
-            "cmdline": [],
+            "cloudinit": "/var/lib/libvirt/images/ubuntu-2404-amd64/commoninit.iso.spec-singular-ubuntu-2404-amd64-agent-1;0c6db798-6b66-4add-a8b6-875a061827de",
+            "cmdline": null,
             "console": [
               {
                 "source_host": "127.0.0.1",
@@ -134,7 +146,7 @@
                 "file": "",
                 "scsi": false,
                 "url": "",
-                "volume_id": "/var/lib/libvirt/images/ubuntu-2404-amd64/vm-image.spec-singular-ubuntu-2404-amd64-agent-0.qcow2",
+                "volume_id": "/var/lib/libvirt/images/ubuntu-2404-amd64/vm-image.spec-singular-ubuntu-2404-amd64-agent-1.qcow2",
                 "wwn": ""
               }
             ],
@@ -147,17 +159,17 @@
             "initrd": "",
             "kernel": "",
             "machine": "pc",
-            "memory": 2048,
+            "memory": 1024,
             "metadata": null,
-            "name": "spec-singular-ubuntu-2404-amd64-agent-0",
+            "name": "spec-singular-ubuntu-2404-amd64-agent-1",
             "network_interface": [
               {
                 "addresses": [
-                  "192.168.100.40",
+                  "192.168.100.37",
                   "fe80::5054:ff:fe4a:ffe6"
                 ],
                 "bridge": "",
-                "hostname": "agent-0",
+                "hostname": "spec-singular-ubuntu-2404-amd64-agent-1",
                 "mac": "52:54:00:4A:FF:E6",
                 "macvtap": "",
                 "network_id": "60fbc68c-bce3-416e-b94a-420021d56e95",
@@ -167,7 +179,7 @@
                 "wait_for_lease": true
               }
             ],
-            "nvram": [],
+            "nvram": null,
             "qemu_agent": true,
             "running": true,
             "timeouts": null,
@@ -181,14 +193,14 @@
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9fQ==",
           "dependencies": [
             "libvirt_network.network",
-            "module.agent.libvirt_cloudinit_disk.commoninit",
-            "module.agent.libvirt_volume.volume_qcow2"
+            "module.vmdomain.libvirt_cloudinit_disk.commoninit",
+            "module.vmdomain.libvirt_volume.volume_qcow2"
           ]
         }
       ]
     },
     {
-      "module": "module.agent[0]",
+      "module": "module.vmdomain[\"spec-singular-ubuntu-2404-amd64-agent-1\"]",
       "mode": "managed",
       "type": "libvirt_volume",
       "name": "volume_qcow2",
@@ -201,8 +213,8 @@
             "base_volume_name": "noble-server-cloudimg-amd64.img",
             "base_volume_pool": "default",
             "format": "qcow2",
-            "id": "/var/lib/libvirt/images/ubuntu-2404-amd64/vm-image.spec-singular-ubuntu-2404-amd64-agent-0.qcow2",
-            "name": "vm-image.spec-singular-ubuntu-2404-amd64-agent-0.qcow2",
+            "id": "/var/lib/libvirt/images/ubuntu-2404-amd64/vm-image.spec-singular-ubuntu-2404-amd64-agent-1.qcow2",
+            "name": "vm-image.spec-singular-ubuntu-2404-amd64-agent-1.qcow2",
             "pool": "ubuntu-2404-amd64.pool",
             "size": 10737418240,
             "source": null,
@@ -217,7 +229,7 @@
       ]
     },
     {
-      "module": "module.primary",
+      "module": "module.vmdomain[\"spec-singular-ubuntu-2404-amd64-primary-1\"]",
       "mode": "managed",
       "type": "libvirt_cloudinit_disk",
       "name": "commoninit",
@@ -226,9 +238,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "/var/lib/libvirt/images/ubuntu-2404-amd64/commoninit.iso.spec-singular-ubuntu-2404-amd64-primary;e3917a72-0488-4323-b099-1d86f54a1123",
-            "meta_data": "instance-id: i-14b061ca-5efc-189c-9162-1e909d6477cb\nlocal-hostname: primary\n",
-            "name": "commoninit.iso.spec-singular-ubuntu-2404-amd64-primary",
+            "id": "/var/lib/libvirt/images/ubuntu-2404-amd64/commoninit.iso.spec-singular-ubuntu-2404-amd64-primary-1;57b48ac2-c3ae-4f82-9afd-633423313964",
+            "meta_data": "instance-id: i-663badd2-cf99-e708-2ff9-04b95f0d08a7\nlocal-hostname: spec-singular-ubuntu-2404-amd64-primary-1\n",
+            "name": "commoninit.iso.spec-singular-ubuntu-2404-amd64-primary-1",
             "network_config": "network:\n  version: 2\n  ethernets:\n    # The primary network interface. The id0 identifier is purely internal\n    # to cloud-init. The actual device name is matched by the match.name\n    # key, since the virtio network device name can vary, but should be\n    # some variation of ens[\\d] or enp[\\d]s[\\d]. (see\n    # https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/)\n    id0:\n      #\n      match:\n        name: en*\n      dhcp4: yes\n      nameservers:\n        addresses: [192.168.100.1]\n      routes:\n      - to: 0.0.0.0/0\n        via: 192.168.100.1\n",
             "pool": "ubuntu-2404-amd64.pool",
             "user_data": "#cloud-config\n# ^^^ warning, this magic comment is necessary for cloud-init to recognize and process this file...\n# https://cloudinit.readthedocs.io/en/latest/explanation/about-cloud-config.html#how-do-i-create-a-cloud-config-file\n#\n# Users and Groups Module\n# https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups\nusers:\n  - name: spec\n    ssh_authorized_keys:\n      - ssh key\n\n    sudo: [\"ALL=(ALL) NOPASSWD:ALL\"]\n    groups: sudo\n    shell: /bin/bash\n# Set Passwords Module\n# https://cloudinit.readthedocs.io/en/latest/reference/modules.html#set-passwords\n# Do not require password change on first login.\nchpasswd: { expire: False }\n# Package Update Upgrade Install Module\n# https://cloudinit.readthedocs.io/en/latest/reference/modules.html#package-update-upgrade-install\n# Ensure qemu agent is installed so that terraform-provider-libvirt can retrieve IP address.\npackages: qemu-guest-agent\n# https://cloudinit.readthedocs.io/en/latest/reference/modules.html#runcmd\nruncmd:\n  - [ systemctl, daemon-reload ]\n  - [ systemctl, enable, qemu-guest-agent.service ]\n  - [ systemctl, start, --no-block, qemu-guest-agent.service ]\n"
@@ -242,7 +254,7 @@
       ]
     },
     {
-      "module": "module.primary",
+      "module": "module.vmdomain[\"spec-singular-ubuntu-2404-amd64-primary-1\"]",
       "mode": "managed",
       "type": "libvirt_domain",
       "name": "domain",
@@ -255,7 +267,7 @@
             "autostart": false,
             "boot_device": [],
             "cloudinit": "/var/lib/libvirt/images/ubuntu-2404-amd64/commoninit.iso.spec-singular-ubuntu-2404-amd64-primary;e3917a72-0488-4323-b099-1d86f54a1123",
-            "cmdline": [],
+            "cmdline": null,
             "console": [
               {
                 "source_host": "127.0.0.1",
@@ -287,7 +299,7 @@
                 "file": "",
                 "scsi": false,
                 "url": "",
-                "volume_id": "/var/lib/libvirt/images/ubuntu-2404-amd64/vm-image.spec-singular-ubuntu-2404-amd64-primary.qcow2",
+                "volume_id": "/var/lib/libvirt/images/ubuntu-2404-amd64/vm-image.spec-singular-ubuntu-2404-amd64-primary-1.qcow2",
                 "wwn": ""
               }
             ],
@@ -300,13 +312,13 @@
             "initrd": "",
             "kernel": "",
             "machine": "pc",
-            "memory": 8192,
+            "memory": 2048,
             "metadata": null,
-            "name": "spec-singular-ubuntu-2404-amd64-primary",
+            "name": "spec-singular-ubuntu-2404-amd64-primary-1",
             "network_interface": [
               {
                 "addresses": [
-                  "192.168.100.158",
+                  "192.168.100.224",
                   "fe80::5054:ff:fe1e:be59"
                 ],
                 "bridge": "",
@@ -320,13 +332,13 @@
                 "wait_for_lease": true
               }
             ],
-            "nvram": [],
+            "nvram": null,
             "qemu_agent": true,
             "running": true,
             "timeouts": null,
             "tpm": [],
             "type": "kvm",
-            "vcpu": 4,
+            "vcpu": 2,
             "video": [],
             "xml": []
           },
@@ -334,14 +346,14 @@
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9fQ==",
           "dependencies": [
             "libvirt_network.network",
-            "module.primary.libvirt_cloudinit_disk.commoninit",
-            "module.primary.libvirt_volume.volume_qcow2"
+            "module.vmdomain.libvirt_cloudinit_disk.commoninit",
+            "module.vmdomain.libvirt_volume.volume_qcow2"
           ]
         }
       ]
     },
     {
-      "module": "module.primary",
+      "module": "module.vmdomain[\"spec-singular-ubuntu-2404-amd64-primary-1\"]",
       "mode": "managed",
       "type": "libvirt_volume",
       "name": "volume_qcow2",
@@ -354,8 +366,8 @@
             "base_volume_name": "noble-server-cloudimg-amd64.img",
             "base_volume_pool": "default",
             "format": "qcow2",
-            "id": "/var/lib/libvirt/images/ubuntu-2404-amd64/vm-image.spec-singular-ubuntu-2404-amd64-primary.qcow2",
-            "name": "vm-image.spec-singular-ubuntu-2404-amd64-primary.qcow2",
+            "id": "/var/lib/libvirt/images/ubuntu-2404-amd64/vm-image.spec-singular-ubuntu-2404-amd64-primary-1.qcow2",
+            "name": "vm-image.spec-singular-ubuntu-2404-amd64-primary-1.qcow2",
             "pool": "ubuntu-2404-amd64.pool",
             "size": 21474836480,
             "source": null,

--- a/spec/functions/generate_terraform_vm_spec_set_spec.rb
+++ b/spec/functions/generate_terraform_vm_spec_set_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe 'kvm_automation_tooling::generate_terraform_vm_spec_set' do
+  let(:cluster_id) { 'test-singular-ubuntu-2404-amd64' }
+  let(:vm_specs) do
+    [
+      {
+        'role' => 'primary',
+        'os' => 'ubuntu',
+        'os_version' => '24.04',
+        'os_arch' => 'x86_64',
+        'cpus' => 4,
+        'mem_mb' => 4096,
+        'disk_gb' => 20,
+      },
+      {
+        'role' => 'agent',
+        'count' => 2,
+        'os' => 'ubuntu',
+        'os_version' => '22.04',
+        'os_arch' => 'x86_64',
+      },
+    ]
+  end
+  let(:image_results) do
+    [
+      {
+        'platform' => 'ubuntu-2404-amd64',
+        'base_image_url' => 'http://example-rspec/noble-server.img',
+        'base_volume_name' => 'noble-server.img',
+        'pool_name' => 'ubuntu-2404-amd64.pool',
+        'pool_path' => 'ubuntu-2404-amd64',
+      },
+      {
+        'platform' => 'ubuntu-2204-amd64',
+        'base_image_url' => 'http://example-rspec/jammy-server.img',
+        'base_volume_name' => 'jammy-server.img',
+        'pool_name' => 'ubuntu-2204-amd64.pool',
+        'pool_path' => 'ubuntu-2204-amd64',
+      },
+    ]
+  end
+
+  it 'returns a hash of per vm terraform objects keyed by hostname' do
+    is_expected.to(
+      run.with_params(cluster_id, vm_specs, image_results)
+        .and_return(
+          {
+            'test-singular-ubuntu-2404-amd64-primary-1' => {
+              'cpus' => 4,
+              'mem_mb' => 4096,
+              'disk_gb' => 20,
+              'base_volume_name' => 'noble-server.img',
+              'pool_name' => 'ubuntu-2404-amd64.pool',
+            },
+            'test-singular-ubuntu-2404-amd64-agent-1' => {
+              'base_volume_name' => 'jammy-server.img',
+              'pool_name' => 'ubuntu-2204-amd64.pool',
+            },
+            'test-singular-ubuntu-2404-amd64-agent-2' => {
+              'base_volume_name' => 'jammy-server.img',
+              'pool_name' => 'ubuntu-2204-amd64.pool',
+            },
+          }
+        )
+    )
+  end
+end

--- a/spec/functions/platform_spec.rb
+++ b/spec/functions/platform_spec.rb
@@ -3,22 +3,46 @@ require 'spec_helper'
 describe 'kvm_automation_tooling::platform' do
   it 'returns a platform string' do
     is_expected.to(
-      run.with_params('ubuntu', '2204', 'amd64')
+      run.with_params({ 'os' => 'ubuntu', 'os_version' => '2204', 'os_arch' => 'amd64' })
         .and_return('ubuntu-2204-amd64')
     )
   end
 
   it 'removes delimeters from ubuntu version strings' do
     is_expected.to(
-      run.with_params('ubuntu', '22.04', 'amd64')
+      run.with_params({ 'os' => 'ubuntu', 'os_version' => '22.04', 'os_arch' => 'amd64'})
         .and_return('ubuntu-2204-amd64')
     )
   end
 
   it 'switches to amd64 for ubuntu arch' do
     is_expected.to(
-      run.with_params('ubuntu', '2204', 'x86_64')
+      run.with_params({ 'os' => 'ubuntu', 'os_version' => '2204', 'os_arch' => 'x86_64'})
         .and_return('ubuntu-2204-amd64')
     )
+  end
+
+  context 'with a Kvm_automation_tooling::Vm_spec' do
+    let(:vm_spec) do
+      {
+        'role' => 'agent',
+        'os' => 'ubuntu',
+        'os_version' => '2204',
+        'os_arch' => 'amd64',
+        'cpus' => 2,
+      }
+    end
+
+    it 'also works' do
+      is_expected.to(run.with_params(vm_spec).and_return('ubuntu-2204-amd64'))
+    end
+
+    it 'raises an error if missing any of the os keys' do
+      vm_spec.delete('os')
+      is_expected.to(
+        run.with_params(vm_spec)
+        .and_raise_error(%r{An os,.*Received:})
+      )
+    end
   end
 end

--- a/spec/functions/resolve_terraform_targets_spec.rb
+++ b/spec/functions/resolve_terraform_targets_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe 'kvm_automation_tooling::resolve_terraform_targets' do
+  include BoltSpec::BoltContext
+
+  let(:tempdir) { Dir.mktmpdir('rspec-kat') }
+
+  # Mock out functions coming from other Bolt modules
+  let(:pre_cond) do
+    <<~PRECOND
+      function log::debug($msg) {
+        notice($msg)
+      }
+      function resolve_references(Hash $group) {
+        {
+          'targets' => [
+            {
+              'name' => 'spec-primary-1',
+              'uri'  => '192.168.100.100',
+            },
+            {
+              'name' => 'spec-agent-1',
+              'uri'  => '192.168.100.200',
+            },
+          ],
+        }
+      }
+    PRECOND
+  end
+
+  around(:each) do |example|
+    in_bolt_context do
+      example.run
+    end
+  ensure
+    FileUtils.remove_entry_secure(tempdir)
+  end
+
+  context 'with an inventory file' do
+    let(:inventory_yaml) do
+      <<~YAML
+        ---
+        groups:
+          - name: puppet
+            vars:
+              domain_name: some.domain
+            targets:
+              _plugin: terraform
+              dir: #{tempdir}
+              state: #{tempdir}/spec.tfstate
+            resource_type: libvirt_domain.domain
+            target_mapping:
+              name: network_interface.0.hostname
+              uri: network_interface.0.addresses.0
+        config:
+          ssh:
+            user: spec
+            run-as: root
+      YAML
+    end
+
+    before(:each) do
+      # Provide a terraform state file for inventory to parse.
+      File.write("#{tempdir}/inventory-spec.yaml", inventory_yaml)
+    end
+
+    it 'resolves the terraform targets matching role in the given inventory file' do
+      result = call_function('kvm_automation_tooling::resolve_terraform_targets', "#{tempdir}/inventory-spec.yaml", 'primary')
+      expect(result).to match_array(
+        have_attributes(
+          name: 'spec-primary-1.some.domain',
+          uri: '192.168.100.100',
+          user: 'spec',
+          vars: {},
+          config: {'ssh' => {'user' => 'spec', 'run-as' => 'root'}},
+        )
+      )
+    end
+
+    context 'but no matching targets' do
+      it 'returns an empty array' do
+        is_expected.to run.with_params("#{tempdir}/inventory-spec.yaml", 'notfound').and_return([])
+      end
+    end
+
+    context 'that is empty' do
+      let(:inventory_yaml) { '' }
+
+      it 'raises an error the group is not in the inventory file' do
+        is_expected.to(
+          run.with_params('/non_existent_file.yaml', 'primary')
+            .and_raise_error(%r{Did not find group 'puppet' in inventory})
+        )
+      end
+    end
+  end
+
+  it 'raises an error if there is no inventory file' do
+    is_expected.to(
+      run.with_params('/non_existent_file.yaml', 'primary')
+        .and_raise_error(%r{Did not find group 'puppet' in inventory})
+    )
+  end
+end

--- a/spec/plans/standup_cluster_spec.rb
+++ b/spec/plans/standup_cluster_spec.rb
@@ -14,6 +14,14 @@ describe 'plan: standup_cluster' do
       'network_addresses'   => '192.168.100.0/24',
       'terraform_state_dir' => tempdir,
       'image_download_dir'  => '/dev/null',
+      'vms' => [
+        {
+          'role' => 'primary',
+          'cpus' => 2,
+          'mem_mb' => 2048,
+          'disk_gb' => 20,
+        },
+      ],
     }
   end
   let(:cluster_id) { 'spec-singular-ubuntu-2404-amd64' }
@@ -25,7 +33,7 @@ describe 'plan: standup_cluster' do
   end
 
   before(:each) do
-    # Provide
+    # Provide a terraform state file for inventory to resolve from.
     FileUtils.cp(File.join(KatRspec.fixture_path, '/terraform/spec.tfstate'), "#{tempdir}/#{cluster_id}.tfstate")
   end
 
@@ -34,11 +42,6 @@ describe 'plan: standup_cluster' do
     before(:each) do
       allow_any_out_message
 
-      expect_command("mkdir -p /dev/null")
-        .with_targets('localhost')
-      expect_task('kvm_automation_tooling::download_image')
-      expect_task('kvm_automation_tooling::import_libvirt_volume')
-      expect_task('kvm_automation_tooling::create_libvirt_image_pool')
       expect_task('terraform::initialize')
       expect_plan('terraform::apply')
         .with_params(
@@ -49,17 +52,82 @@ describe 'plan: standup_cluster' do
         )
     end
 
-    it 'terraforms and installs openvox' do
-      allow_apply_prep
+    context 'for a single platform' do
+      before(:each) do
+        expect_command("mkdir -p /dev/null")
+          .with_targets('localhost')
+        expect_task('kvm_automation_tooling::download_image')
+        expect_task('kvm_automation_tooling::import_libvirt_volume')
+        expect_task('kvm_automation_tooling::create_libvirt_image_pool')
+      end
 
-      result = run_plan('kvm_automation_tooling::standup_cluster', params)
-      expect(result.ok?).to(eq(true), result.value)
+      it 'terraforms and installs openvox' do
+        allow_apply_prep
+
+        result = run_plan('kvm_automation_tooling::standup_cluster', params)
+        expect(result.ok?).to(eq(true), result.value)
+      end
+
+      it 'just terraforms when install_openvox is false' do
+        params['install_openvox'] = false
+        result = run_plan('kvm_automation_tooling::standup_cluster', params)
+        expect(result.ok?).to(eq(true), result.value)
+      end
     end
 
-    it 'just terraforms when install_openvox is false' do
-      params['install_openvox'] = false
-      result = run_plan('kvm_automation_tooling::standup_cluster', params)
-      expect(result.ok?).to(eq(true), result.value)
+    context 'with multiple vm platforms' do
+      before(:each) do
+        expect_command("mkdir -p /dev/null")
+          .with_targets('localhost')
+          .be_called_times(2)
+
+        # Expect ubuntu 24.04
+        expect_task('kvm_automation_tooling::download_image')
+          .with_params(
+            'image_url' => 'https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img',
+            'download_dir' => '/dev/null',
+          )
+        expect_task('kvm_automation_tooling::import_libvirt_volume')
+          .with_params(
+            'image_path' => '/dev/null/noble-server-cloudimg-amd64.img',
+            'volume_name' => 'noble-server-cloudimg-amd64.img',
+          )
+        expect_task('kvm_automation_tooling::create_libvirt_image_pool')
+          .with_params(
+            'name' => 'ubuntu-2404-amd64.pool',
+            'path' => 'ubuntu-2404-amd64',
+          )
+
+        # And expect ubuntu 22.04
+        expect_task('kvm_automation_tooling::download_image')
+          .with_params(
+            'image_url' => 'https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img',
+            'download_dir' => '/dev/null',
+          )
+        expect_task('kvm_automation_tooling::import_libvirt_volume')
+          .with_params(
+            'image_path' => '/dev/null/jammy-server-cloudimg-amd64.img',
+            'volume_name' => 'jammy-server-cloudimg-amd64.img',
+          )
+        expect_task('kvm_automation_tooling::create_libvirt_image_pool')
+          .with_params(
+            'name' => 'ubuntu-2204-amd64.pool',
+            'path' => 'ubuntu-2204-amd64',
+          )
+
+        allow_apply_prep
+      end
+
+      it 'manages all platforms' do
+        params['vms'] << {
+          'role' => 'agent',
+          'os' => 'ubuntu',
+          'os_version' => '22.04',
+          'os_arch' => 'x86_64',
+        }
+        result = run_plan('kvm_automation_tooling::standup_cluster', params)
+        expect(result.ok?).to(eq(true), result.value)
+      end
     end
   end
 end

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,38 +24,16 @@ resource "libvirt_network" "network" {
   }
 }
 
-# The puppet-server/db/postgresql node
-module "primary" {
+module "vmdomain" {
   source = "./modules/vm"
-  count = var.primary_count
-  cluster_id = var.cluster_id
-  hostname = "primary"
-  pool_name = var.pool_name
-  base_volume_name = var.base_volume_name
-  cpu_mode = var.cpu_mode
-  cpus = var.primary_cpus
-  memory = var.primary_memory
-  disk_size = var.primary_disk_size
-  gateway_ip = local.gateway_ip
-  network_id = libvirt_network.network.id
-  user_name = var.user_name
-  user_password = var.user_password
-  ssh_public_key = local.ssh_public_key
-  depends_on = [libvirt_network.network]
-}
-
-# The puppet-agent nodes
-module "agent" {
-  source = "./modules/vm"
-  count = var.agent_count
-  cluster_id = var.cluster_id
-  hostname = "agent-${count.index}"
-  pool_name = var.pool_name
-  base_volume_name = var.base_volume_name
-  cpu_mode = var.cpu_mode
-  cpus = var.agent_cpus
-  memory = var.agent_memory
-  disk_size = var.agent_disk_size
+  for_each = var.vm_specs
+  hostname = each.key
+  pool_name = each.value.pool_name
+  base_volume_name = each.value.base_volume_name
+  cpu_mode = each.value.cpu_mode
+  cpus = each.value.cpus
+  mem_mb = each.value.mem_mb
+  disk_gb = each.value.disk_gb
   gateway_ip = local.gateway_ip
   network_id = libvirt_network.network.id
   user_name = var.user_name

--- a/terraform/modules/vm/locals.tf
+++ b/terraform/modules/vm/locals.tf
@@ -1,6 +1,4 @@
 locals {
-  identifier = "${var.cluster_id}-${var.hostname}"
-
   # The path to the cloud-init configuration templates
   cloud_init_path = "${path.module}/../../../cloud-init"
   user_data = templatefile(

--- a/terraform/modules/vm/main.tf
+++ b/terraform/modules/vm/main.tf
@@ -8,12 +8,12 @@ terraform {
 }
 
 resource "libvirt_volume" "volume_qcow2" {
-  name   = "vm-image.${local.identifier}.qcow2"
+  name   = "vm-image.${var.hostname}.qcow2"
   pool   = var.pool_name
   base_volume_name = var.base_volume_name
   base_volume_pool = "default"
   format = "qcow2"
-  size   = var.disk_size * local.gigabyte # need to use cloud-init to grow the partition?
+  size   = var.disk_gb * local.gigabyte # need to use cloud-init to grow the partition?
 }
 
 # for more info about parameters check this out
@@ -21,7 +21,7 @@ resource "libvirt_volume" "volume_qcow2" {
 # Use CloudInit to add our ssh-key to the instance
 # you can add also meta_data field
 resource "libvirt_cloudinit_disk" "commoninit" {
-  name           = "commoninit.iso.${local.identifier}"
+  name           = "commoninit.iso.${var.hostname}"
   user_data      = local.user_data
   network_config = local.network_config
   meta_data      = local.meta_data
@@ -30,8 +30,8 @@ resource "libvirt_cloudinit_disk" "commoninit" {
 
 # Create the machine
 resource "libvirt_domain" "domain" {
-  name   = "${local.identifier}"
-  memory = var.memory
+  name   = var.hostname
+  memory = var.mem_mb
   vcpu   = var.cpus
   qemu_agent = true
 

--- a/terraform/modules/vm/variables.tf
+++ b/terraform/modules/vm/variables.tf
@@ -1,8 +1,3 @@
-variable "cluster_id" {
-  description = "An identifier for the cluster, used as part of each generated libvirt object id."
-  type = string
-}
-
 variable "hostname" {
   description = "The hostname to set for the VM."
   type = string
@@ -26,16 +21,22 @@ variable "cpu_mode" {
 variable "cpus" {
   description = "The number of CPUs to allocate to the VM."
   type = number
+  default = 1
+  nullable = false
 }
 
-variable "memory" {
+variable "mem_mb" {
   description = "The amount of memory in MB to allocate to the VM."
   type = number
+  default = 1024
+  nullable = false
 }
 
-variable "disk_size" {
+variable "disk_gb" {
   description = "The size of the VM disk in GB."
   type = number
+  default = 10
+  nullable = false
 }
 
 variable "user_name" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,9 +1,4 @@
-output "primary_ip_address" {
-  description = "The IP address of the primary vm."
-  value = module.primary[*].ip_address
-}
-
-output "agent_ip_addresses" {
-  description = "An array of the IP addresses of the agent vms."
-  value = module.agent[*].ip_address
+output "vm_ip_addresses" {
+  description = "An array of the IP addresses of the vms."
+  value = module.vmdomain
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,16 +10,6 @@ variable "cluster_id" {
   default = "dev"
 }
 
-variable "pool_name" {
-  description = "Identifier for the libvirt image pool to use for the VM images."
-  type = string
-}
-
-variable "base_volume_name" {
-  description = "The name of the libvirt volume to use as the base image for the VM images."
-  type = string
-}
-
 variable "user_name" {
   description = "The name of the user account to create for ssh login on generated vm hosts."
   type = string
@@ -47,64 +37,22 @@ variable "user_password" {
   nullable = false
 }
 
-variable "cpu_mode" {
-  description = "The CPU mode to use for the VMs."
-  type = string
-}
-
-########################################################################
-# Primary node variables
-
-variable "primary_count" {
-  description = "The number of primary nodes to create in the cluster."
-  type = number
-  default = 1
-  validation {
-    condition     = var.primary_count >= 0 && var.primary_count <= 1
-    error_message = "The primary_count may be 0 or 1."
-  }
-}
-
-variable "primary_cpus" {
-  description = "The number of CPUs to allocate to the primary node."
-  type = number
-  default = 4
-}
-
-variable "primary_memory" {
-  description = "The amount of memory in MB to allocate to the primary node."
-  type = number
-  default = 8192
-}
-
-variable "primary_disk_size" {
-  description = "The size of the primary node disk in GB."
-  type = number
-  default = 20
-}
-
-########################################################################
-# Agent node variables
-
-variable "agent_count" {
-  description = "The number of agent nodes to create in the cluster."
-  type = number
-}
-
-variable "agent_cpus" {
-  description = "The number of CPUs to allocate to each agent node."
-  type = number
-  default = 2
-}
-
-variable "agent_memory" {
-  description = "The amount of memory in MB to allocate to each agent node."
-  type = number
-  default = 2048
-}
-
-variable "agent_disk_size" {
-  description = "The size of each agent node disk in GB."
-  type = number
-  default = 10
+variable "vm_specs" {
+  description = "A map of vm specifications to use for generating VMs with the vm module. The keys are the unique hostname string for each VM, and the values are an object with configuration details for the vm module."
+  type = map(object({
+    # Identifier for the libvirt image pool to use for the VM images.
+    pool_name = string
+    # The name of the libvirt volume to use as the base image for the
+    # VM images.
+    base_volume_name = string
+    # The number of CPUs to allocate to each vm.
+    cpus      = optional(number)
+    # The amount of memory in MB to allocate to each vm.
+    mem_mb    = optional(number)
+    # The size of each vm disk in GB.
+    disk_gb   = optional(number)
+    # The CPU mode to use for the VMs.
+    # (Set to host-passthrough for nested virtualization.)
+    cpu_mode  = optional(string)
+  }))
 }

--- a/types/vm_spec.pp
+++ b/types/vm_spec.pp
@@ -1,0 +1,29 @@
+# Specification for a set of vms of some count.
+#
+# Only the base role key is required. The rest of the keys are optional
+# so that a set of common parameters can be used with the fill_vm_spec()
+# function to supply any missing defaults.
+#
+# Keys:
+# - role: The role of the vms in set. Will be used as part of the
+#   hostname along with the cluster-id and the vm count. (Required)
+# - count: The number of vms in the set.
+# - os: The operating system of the vms.
+# - os_version: The version of the operating system of the vms.
+# - os_arch: The chip architecture of the operating system of the vms.
+# - cpus: The number of CPUs to allocate to each vm.
+# - mem_mb: The amount of memory in MB to allocate to each vm.
+# - disk_gb: The amount of disk space in GB to allocate to each vm.
+# - cpu_mode: The CPU mode to use for the libvirt vm domains. Set this
+#   to 'host-passthrough' to enable nested virtualization.
+type Kvm_automation_tooling::Vm_spec = Struct[{
+  role => String[1],
+  Optional[count]      => Integer[1],
+  Optional[os]         => Kvm_automation_tooling::Operating_system,
+  Optional[os_version] => Kvm_automation_tooling::Version,
+  Optional[os_arch]    => Kvm_automation_tooling::Os_arch,
+  Optional[cpus]       => Integer[1],
+  Optional[mem_mb]     => Integer[1],
+  Optional[disk_gb]    => Integer[1],
+  Optional[cpu_mode]   => String[1],
+}]


### PR DESCRIPTION
Replaces standup_cluster primary_* and agent_* parameters with a
single vms parameter taking an Array of Vm_spec definitions. This allows
generation of sets of vms for any arbitrary role.

Also allows vm sets to be defined with different os platforms.

The same changes are threaded through to the terraform manifests which
now take a single vm_specs variable that has a map of vm object
defintions keyed by unique hostname.

So providing standup_cluster with a params.json like:

```json
{
  "cluster_name": "test",
  "network_addresses": "192.168.100.0/24",
  "ssh_public_key_path": "/home/jpartlow/.ssh/id_vms.ed25519.pub",
  "os": "ubuntu",
  "os_version": "2404",
  "os_arch": "x86_64",
  "vms": [
    {
      "role": "primary",
      "cpus": 4,
      "mem_mb": 8192,
      "disk_gb": 20
    },
    {
      "role": "agent",
      "count": 2
    },
    {
      "role": "runner",
      "os": "ubuntu",
      "os_version": "2204",
      "os_arch": "x86_64",
    }
  ]
}
```

Will generate four vms, an ubuntu-2404 primary:
 - test-singular-ubuntu-2404-amd64-primary-1

Two ubuntu-2404 agents:
 - test-singular-ubuntu-2404-amd64-agent-1
 - test-singular-ubuntu-2404-amd64-agent-2

And an ubuntu-2204 runner:
 - test-singular-ubuntu-2204-amd64-runner-1

The agent and runner sets will have default cpu, mem and
disk settings provided by the terraform manifests.