### PR TITLE
(plans) Add a dev plan to generate a beaker host file from inventory

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,11 @@ inputs:
     description: 'Operating system arch to use for the cluster'
     required: true
     type: string
+  ruby-version:
+    description: 'Ruby version to install for the action'
+    required: true
+    type: string
+    default: '3.3'
   vms:
     description: |-
       JSON array of VM definitions as defined by the
@@ -69,7 +74,7 @@ runs:
         sudo virsh pool-create-as --name default --type dir --target /var/lib/libvirt/images
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2'
+        ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: true
         working-directory: kvm_automation_tooling
     - name: Install module dependencies

--- a/plans/dev/generate_beaker_hosts_file.pp
+++ b/plans/dev/generate_beaker_hosts_file.pp
@@ -1,0 +1,17 @@
+# Convert the puppet inventory group into a hosts.yaml file for
+# use with Beaker.
+#
+# @param $hosts The hosts to include in the hosts.yaml file.
+# @param $hosts_yaml An absolute path of the hosts file to generate.
+plan kvm_automation_tooling::dev::generate_beaker_hosts_file(
+  TargetSpec $hosts = 'puppet',
+  String[1] $hosts_yaml = '/tmp/hosts.yaml',
+) {
+  $host_targets = get_targets($hosts)
+  # This has the side effect of setting a 'platform' variable on each agent target.
+  run_plan('kvm_automation_tooling::subplans::lookup_platform', 'targets' => $host_targets)
+  $hosts_yaml_content = epp('kvm_automation_tooling/beaker-hosts.yaml.epp', {
+    'agents' => $host_targets,
+  })
+  file::write($hosts_yaml, $hosts_yaml_content)
+}

--- a/plans/dev/openvox_agent_acceptance.pp
+++ b/plans/dev/openvox_agent_acceptance.pp
@@ -43,16 +43,16 @@ plan kvm_automation_tooling::dev::openvox_agent_acceptance(
     | EOS
 
   out::message('Create a hosts.yaml file for beaker.')
-  # This has the side effect of setting a 'platform' variable on each agent target.
-  run_plan('kvm_automation_tooling::subplans::lookup_platform', 'targets' => $agents)
-  $hosts_yaml = epp('kvm_automation_tooling/beaker-hosts.yaml.epp', {
-    'agents' => get_targets($agents),
+  $host_yaml = '/tmp/openvox_agents-beaker-hosts.yaml'
+  run_plan('kvm_automation_tooling::dev::generate_beaker_hosts_file', {
+    'hosts'      => $agents,
+    'hosts_yaml' => $host_yaml,
   })
-  run_command(@("EOS"), $runner, '_run_as' => $user)
-    cat > openvox-agent/acceptance/hosts.yaml <<EOF
-    ${hosts_yaml}
-    EOF
-    | EOS
+  upload_file(
+    $host_yaml,
+    "/home/${user}/openvox-agent/acceptance/hosts.yaml",
+    $runner,
+  )
 
   out::message('Run beaker.')
   run_command(@(EOS), $runner, '_run_as' => $user)

--- a/templates/beaker-hosts.yaml.epp
+++ b/templates/beaker-hosts.yaml.epp
@@ -4,6 +4,7 @@ HOSTS:
 <%- $agents.each |$agent| {-%>
   <%= $agent.name %>:
     vmhostname: '<%= "${agent.name}.vm" %>'
+    ip: '<%= $agent.uri %>'
     roles:
       - agent
     platform: '<%= $agent.vars['platform'] %>'


### PR DESCRIPTION
Used to transform Bolt inventory (ultimately tfstate data) into a Beaker hosts.yaml format suitable for running beaker tests against.

Helpful in gha workflows.