### PR TITLE
(gha) Provide defaults for collection/version in action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -153,8 +153,8 @@ runs:
         SETUP_CLUSTER_ROOT_SSH: ${{ inputs.setup-cluster-root-ssh }}
         HOST_ROOT_ACCESS: ${{ inputs.host-root-access }}
         INSTALL_OPENVOX: ${{ inputs.install-openvox }}
-        OPENVOX_COLLECTION: ${{ inputs.openvox-collection }}
-        OPENVOX_VERSION: ${{ inputs.openvox-version }}
+        OPENVOX_COLLECTION: ${{ inputs.openvox-collection || 'openvox8' }}
+        OPENVOX_VERSION: ${{ inputs.openvox-version || 'latest' }}
         OPENVOX_RELEASED: ${{ inputs.openvox-released }}
         OPENVOX_ARTIFACTS_URL: ${{ inputs.openvox-artifacts-url }}
       working-directory: kvm_automation_tooling


### PR DESCRIPTION
The inputs have defaults, but that doesn't handle the case of a calling workflow passing an empty string to either collection or version. This would throw an error from the
Kvm_automation_tooling::Openvox_install_params type. Providing defaults here to the env vars before constructing the standup_cluster_params.json is a simple way to ensure the install_openvox_params structure is well-formed.