### PR TITLE
(maint) Pin to openvox_bootstrap 0.2.1

### DIFF
--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -13,4 +13,4 @@ modules:
   - git: https://github.com/jpartlow/puppetlabs-terraform
     ref: maint-bump-ruby_task_helper-dependency-for-puppet-8
   - git: https://github.com/jpartlow/openvox_bootstrap
-    ref: 0.2.0
+    ref: 0.2.1


### PR DESCRIPTION
Version 0.2.0 had a bug in the retry logic and wasn't actually retrying on failed commands. The gha run for the pr just happened to be lucky and didn't see an rpm lock. The gha run for the commit to main did...wheee.