### PR TITLE
(maint) Update openvox_bootstrap to puppet-openvox_bootstrap

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -80,7 +80,7 @@ inputs:
       URL to the openvox build artifacts. Used to download pre-release
       openvox rpm or deb packages directly, if openvox-released is set
       to false.
-    default: 'https://s3.osuosl.org/openvox-artifacts'
+    default: 'https://artifacts.voxpupuli.org'
   setup-cluster-ssh:
     description: |-
       If true, generated VMs with controller roles ('primary' or

--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -13,4 +13,4 @@ modules:
   - git: https://github.com/jpartlow/puppetlabs-terraform
     ref: maint-bump-ruby_task_helper-dependency-for-puppet-8
   - git: https://github.com/jpartlow/puppet-openvox_bootstrap
-    ref: 0.2.1
+    ref: v0

--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -12,5 +12,5 @@ modules:
     version_requirement: '>= 3.1.0 < 4.0.0'
   - git: https://github.com/jpartlow/puppetlabs-terraform
     ref: maint-bump-ruby_task_helper-dependency-for-puppet-8
-  - git: https://github.com/jpartlow/openvox_bootstrap
+  - git: https://github.com/jpartlow/puppet-openvox_bootstrap
     ref: 0.2.1

--- a/plans/dev/openvox_agent_acceptance.pp
+++ b/plans/dev/openvox_agent_acceptance.pp
@@ -27,7 +27,7 @@ plan kvm_automation_tooling::dev::openvox_agent_acceptance(
   out::message('Install ruby and packages required for rubygem native builds.')
   $runner_target = get_target($runner)
   run_plan('facts', 'targets' => $runner_target)
-  if $runner_target.facts()['aio_agent_version'] == undef{
+  if ($runner_target.facts()['aio_agent_version'] == undef) {
     apply_prep($runner_target)
   }
   apply($runner_target) {

--- a/spec/plans/standup_cluster_spec.rb
+++ b/spec/plans/standup_cluster_spec.rb
@@ -121,10 +121,11 @@ describe 'plan: standup_cluster' do
         expect_task('openvox_bootstrap::install')
           .with_targets(['spec-primary-1.vm', 'spec-agent-1.vm'])
           .with_params({
+            'package'    => 'openvox-agent',
             'version'    => 'latest',
             'collection' => 'openvox8',
-            'apt_source' => 'https://apt.overlookinfratech.com',
-            'yum_source' => 'https://yum.overlookinfratech.com',
+            'apt_source' => 'https://apt.voxpupuli.org',
+            'yum_source' => 'https://yum.voxpupuli.org',
           })
         expect_plan('facts')
 

--- a/spec/plans/subplans/install_openvox_spec.rb
+++ b/spec/plans/subplans/install_openvox_spec.rb
@@ -24,10 +24,11 @@ describe 'plan: install_openvox' do
     expect_task('openvox_bootstrap::install')
       .with_targets(targets)
       .with_params({
+        'package'    => 'openvox-agent',
         'version'    => 'latest',
         'collection' => 'openvox8',
-        'apt_source' => 'https://apt.overlookinfratech.com',
-        'yum_source' => 'https://yum.overlookinfratech.com',
+        'apt_source' => 'https://apt.voxpupuli.org',
+        'yum_source' => 'https://yum.voxpupuli.org',
       })
 
     result = run_plan('kvm_automation_tooling::subplans::install_openvox', params)
@@ -39,10 +40,11 @@ describe 'plan: install_openvox' do
     expect_task('openvox_bootstrap::install')
       .with_targets(targets)
       .with_params({
+        'package'    => 'openvox-agent',
         'version'    => '7.0.0',
         'collection' => 'openvox7',
-        'apt_source' => 'https://apt.overlookinfratech.com',
-        'yum_source' => 'https://yum.overlookinfratech.com',
+        'apt_source' => 'https://apt.voxpupuli.org',
+        'yum_source' => 'https://yum.voxpupuli.org',
       })
 
     result = run_plan('kvm_automation_tooling::subplans::install_openvox', params)
@@ -57,7 +59,7 @@ describe 'plan: install_openvox' do
       .with_params({
         'version'    => '9.0.0',
         'package'    => 'openvox-agent',
-        'artifacts_source' => 'https://s3.osuosl.org/openvox-artifacts',
+        'artifacts_source' => 'https://artifacts.voxpupuli.org',
       })
 
     result = run_plan('kvm_automation_tooling::subplans::install_openvox', params)


### PR DESCRIPTION
The openvox_bootstrap module is been renamed to match voxpupuli naming scheme ahead of it being moved into that org.