### PR TITLE
(maint) Switch to voxpupuli/puppet-openvox_bootstrap

### DIFF
--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -12,5 +12,5 @@ modules:
     version_requirement: '>= 3.1.0 < 4.0.0'
   - git: https://github.com/jpartlow/puppetlabs-terraform
     ref: maint-bump-ruby_task_helper-dependency-for-puppet-8
-  - git: https://github.com/jpartlow/puppet-openvox_bootstrap
+  - git: https://github.com/voxpupuli/puppet-openvox_bootstrap
     ref: v0


### PR DESCRIPTION
Module has moved over to the voxpupuli namespace.