### PR TITLE
(gha-19) openvox_artifacts_url ignored

### DIFF
--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -24,7 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install libvirt-dev library for ruby-libvirt gem
-        run: sudo apt-get install libvirt-dev
+        run: |-
+          sudo apt update
+          sudo apt install libvirt-dev
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}

--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -36,3 +36,13 @@ jobs:
           ln -s kvm_automation_tooling/.modules/ruby_task_helper ../ruby_task_helper
       - name: Run RSpec
         run: bundle exec rspec
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - name: Run puppet-lint
+        run: bundle exec puppet-lint manifests functions plans templates

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,1 @@
+--no-strict_indent-check

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem 'bcrypt_pbkdf', ['>= 1.0', '< 2.0']
 group :development do
   gem 'bolt', '~> 4.0' # provides bolt_spec for tests
   gem 'pry-byebug'
+  gem 'puppet-lint'
+  gem 'voxpupuli-puppet-lint-plugins', '~> 5.0'
   gem 'rspec', '~> 3.0'
   gem 'rspec-puppet', '~> 5.0'
 end

--- a/functions/generate_terraform_vm_spec_set.pp
+++ b/functions/generate_terraform_vm_spec_set.pp
@@ -18,7 +18,6 @@ function kvm_automation_tooling::generate_terraform_vm_spec_set(
   Array[Hash] $image_results,
 ) >> Hash[String, Hash] {
   $vm_specs.reduce({}) |$map, $spec| {
-
     $platform = kvm_automation_tooling::platform($spec['os'])
     $os_name = dig($spec, 'os', 'name')
     $count = $spec['count'] =~ Undef ? {

--- a/functions/translate_os_version_codename.pp
+++ b/functions/translate_os_version_codename.pp
@@ -38,7 +38,6 @@ function kvm_automation_tooling::translate_os_version_codename(
   }
 
   case $os {
-
     'debian','ubuntu': {
       if $version_or_codename =~ Kvm_automation_tooling::Version {
         $_version = ($os == 'debian') ? {

--- a/plans/dev/openvox_agent_acceptance.pp
+++ b/plans/dev/openvox_agent_acceptance.pp
@@ -45,6 +45,7 @@ plan kvm_automation_tooling::dev::openvox_agent_acceptance(
       }
       'RedHat': {
         $packages = [
+          'redhat-rpm-config', # for building bcrypt_pbkdf gem
           'ruby-devel',
           'rubygem-bundler',
           'make',

--- a/plans/subplans/install_openvox.pp
+++ b/plans/subplans/install_openvox.pp
@@ -53,7 +53,7 @@ plan kvm_automation_tooling::subplans::install_openvox(
   } else {
     $_artifacts_url = $install_params['openvox_artifacts_url']
     $install_build_params = $_artifacts_url =~ NotUndef ? {
-      'true' => {
+      true    => {
         'artifacts_source' => $_artifacts_url,
       },
       default => {},

--- a/plans/subplans/manage_base_image_volume.pp
+++ b/plans/subplans/manage_base_image_volume.pp
@@ -5,7 +5,6 @@ plan kvm_automation_tooling::subplans::manage_base_image_volume(
   Kvm_automation_tooling::Os_spec $os_spec,
   String $image_download_dir,
 ) {
-
   $platform = kvm_automation_tooling::platform($os_spec)
 
   run_command("mkdir -p ${image_download_dir}", 'localhost')

--- a/plans/subplans/setup_cluster_ssh.pp
+++ b/plans/subplans/setup_cluster_ssh.pp
@@ -38,7 +38,6 @@ plan kvm_automation_tooling::subplans::setup_cluster_ssh(
   if $controllers.empty() {
     out::message('No controller VMs found. Skipping internal cluster ssh setup.')
   } else {
-
     $ssh_results = run_task('kvm_automation_tooling::generate_keypair',
       'localhost',
       'type' => $key_type,

--- a/spec/plans/subplans/install_openvox_spec.rb
+++ b/spec/plans/subplans/install_openvox_spec.rb
@@ -65,4 +65,20 @@ describe 'plan: install_openvox' do
     result = run_plan('kvm_automation_tooling::subplans::install_openvox', params)
     expect(result.ok?).to(eq(true), result.value.to_s)
   end
+
+  it 'installs from a different artifacts_source' do
+    params['openvox_version'] = '9.0.0'
+    params['openvox_released'] = false
+    params['openvox_artifacts_url'] = 'https://some.other'
+    expect_task('openvox_bootstrap::install_build_artifact')
+      .with_targets(targets)
+      .with_params({
+        'version'    => '9.0.0',
+        'package'    => 'openvox-agent',
+        'artifacts_source' => 'https://some.other',
+      })
+
+    result = run_plan('kvm_automation_tooling::subplans::install_openvox', params)
+    expect(result.ok?).to(eq(true), result.value.to_s)
+  end
 end


### PR DESCRIPTION
Calls into standup_cluster where the install_openvox_params hash had the
openvox_artifacts_url set were pulling resources from the default
artifacts server rather than whatever openvox_artifacts_url had
specified.

This was because of a bad selector case that was trying to evaluate
against the string 'true' instead of the actual value true.

---

Also includes some lint fixes.