### PR TITLE
(plans) Return host ip, openvox versions from standup_cluster plan

### DIFF
--- a/plans/standup_cluster.pp
+++ b/plans/standup_cluster.pp
@@ -255,7 +255,18 @@ plan kvm_automation_tooling::standup_cluster(
     )
 
     out::message("Installed versions: ${stdlib::to_json_pretty($version_map)}")
+  } else {
+    $version_map = {}
   }
 
-  return($target_map)
+  $output = $all_targets.reduce({}) |$map, $target| {
+    $map + {
+      $target.name => {
+        'ip'       => $target.uri,
+        'role'     => $target.vars['role'],
+        'platform' => $target.vars['platform'],
+      } + $version_map.get($target.name, {})
+    }
+  }
+  return($output)
 }


### PR DESCRIPTION
Improves the hash of information returned by the standup_cluster plan from a hash of role => hostname arrays to a hash keyed by hostname that provides ip, role, platform and openvox package versions (if install_openvox was true).

Changes to the resolve_terraform_targets() functions better mirror what subsequent plan runs with the generated inventory file would produce as targets:

* ensures that the group vars are added to each target
* does not append domain name to the name

The later change should have no functional impact since the plans target by uri which is set to the ip address. Whether or not a vm's fqdn is resolvable from the runner host is a question of whether the host is configured to provide it.