### PR TITLE
(maint) Drop debian-10 from testing matrix

### DIFF
--- a/.github/workflows/plan_testing.yaml
+++ b/.github/workflows/plan_testing.yaml
@@ -21,7 +21,6 @@ jobs:
         os:
           - ['almalinux', '8', 'x86_64']
           - ['almalinux', '9', 'x86_64']
-          - ['debian', '10', 'x86_64']
           - ['debian', '11', 'x86_64']
           - ['debian', '12', 'x86_64']
           - ['rocky', '8', 'x86_64']

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ TODO:
 ## OS Support
 
 * Almalinux 9, 8
-* Debian 13, 12, 11, 10
+* Debian 13, 12, 11
 * Rocky 9, 8
 * Ubuntu 24.04, 22.04, 20.04, 18.04
 


### PR DESCRIPTION
Debian 10 was eol last year. Packages have now been dropped from the main deb.debian.org mirrors and are now available only from archive.debian.org, so the images no longer work correctly.