### PR TITLE
Update version requirement for puppet-openvox_bootstrap

### DIFF
--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -13,4 +13,4 @@ modules:
   - git: https://github.com/jpartlow/puppetlabs-terraform
     ref: include-module-when-resolving-references
   - name: puppet-openvox_bootstrap
-    version_requirement: '>= 0.3 < 1.0.0'
+    version_requirement: '>= 1.3.0'

--- a/plans/dev/openvox_acceptance.pp
+++ b/plans/dev/openvox_acceptance.pp
@@ -55,7 +55,6 @@ plan kvm_automation_tooling::dev::openvox_acceptance(
         # ... skipping the pre_suite steps that install puppet packages
         'suites/pre_suite/foss/71_smoke_test_puppetserver.rb',
         'suites/pre_suite/foss/80_configure_puppet.rb',
-        'suites/pre_suite/foss/85_configure_sut.rb',
         'suites/pre_suite/foss/90_validate_sign_cert.rb',
         'suites/pre_suite/foss/95_install_pdb.rb',
         'suites/pre_suite/foss/99_collect_data.rb',

--- a/spec/plans/install_openvox_spec.rb
+++ b/spec/plans/install_openvox_spec.rb
@@ -30,6 +30,7 @@ describe 'plan: install_openvox' do
         'collection' => 'openvox8',
         'apt_source' => 'https://apt.voxpupuli.org',
         'yum_source' => 'https://yum.voxpupuli.org',
+        'stop_service' => false,
       })
     expect_task('package')
       .with_targets(all_targets)
@@ -62,6 +63,7 @@ describe 'plan: install_openvox' do
         'collection' => 'openvox7',
         'apt_source' => 'https://apt.voxpupuli.org',
         'yum_source' => 'https://yum.voxpupuli.org',
+        'stop_service' => false,
       })
     expect_task('package')
 
@@ -129,6 +131,7 @@ describe 'plan: install_openvox' do
           'collection' => 'openvox8',
           'apt_source' => 'https://apt.voxpupuli.org',
           'yum_source' => 'https://yum.voxpupuli.org',
+          'stop_service' => false,
         })
       expect_task('openvox_bootstrap::install')
         .with_targets(primary_targets)
@@ -138,6 +141,7 @@ describe 'plan: install_openvox' do
           'collection' => 'openvox8',
           'apt_source' => 'https://apt.voxpupuli.org',
           'yum_source' => 'https://yum.voxpupuli.org',
+          'stop_service' => false,
         })
       expect_task('openvox_bootstrap::install')
         .with_targets(primary_targets)
@@ -147,6 +151,7 @@ describe 'plan: install_openvox' do
           'collection' => 'openvox8',
           'apt_source' => 'https://apt.voxpupuli.org',
           'yum_source' => 'https://yum.voxpupuli.org',
+          'stop_service' => false,
         })
       expect_task('openvox_bootstrap::install')
         .with_targets(primary_targets)
@@ -156,6 +161,7 @@ describe 'plan: install_openvox' do
           'collection' => 'openvox8',
           'apt_source' => 'https://apt.voxpupuli.org',
           'yum_source' => 'https://yum.voxpupuli.org',
+          'stop_service' => false,
         })
       expect_task('package')
         .with_targets(all_targets)
@@ -225,6 +231,7 @@ describe 'plan: install_openvox' do
           'collection' => 'openvox8',
           'apt_source' => 'https://apt.voxpupuli.org',
           'yum_source' => 'https://yum.voxpupuli.org',
+          'stop_service' => false,
         })
       allow_apply
       expect_task('openvox_bootstrap::install_build_artifact')
@@ -242,6 +249,7 @@ describe 'plan: install_openvox' do
           'collection' => 'openvox8',
           'apt_source' => 'https://apt.voxpupuli.org',
           'yum_source' => 'https://yum.voxpupuli.org',
+          'stop_service' => false,
         })
       expect_task('openvox_bootstrap::install')
         .with_targets(primary_targets)
@@ -251,6 +259,7 @@ describe 'plan: install_openvox' do
           'collection' => 'openvox8',
           'apt_source' => 'https://apt.voxpupuli.org',
           'yum_source' => 'https://yum.voxpupuli.org',
+          'stop_service' => false,
         })
       expect_task('package').be_called_times(4)
 
@@ -281,6 +290,7 @@ describe 'plan: install_openvox' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('openvox_bootstrap::install')
           .with_targets(primary_targets)
@@ -290,6 +300,7 @@ describe 'plan: install_openvox' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('openvox_bootstrap::install')
           .with_targets(primary_targets)
@@ -299,6 +310,7 @@ describe 'plan: install_openvox' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('package').be_called_times(3)
           .always_return({
@@ -333,6 +345,7 @@ describe 'plan: install_openvox' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('openvox_bootstrap::install')
           .with_targets(primary_targets)
@@ -342,6 +355,7 @@ describe 'plan: install_openvox' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('package').be_called_times(2)
           .always_return({
@@ -378,6 +392,7 @@ describe 'plan: install_openvox' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('openvox_bootstrap::install')
           .with_targets(server_targets)
@@ -387,6 +402,7 @@ describe 'plan: install_openvox' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('openvox_bootstrap::install')
           .with_targets(db_targets)
@@ -396,6 +412,7 @@ describe 'plan: install_openvox' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('openvox_bootstrap::install')
           .with_targets(server_targets)
@@ -405,6 +422,7 @@ describe 'plan: install_openvox' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('package').be_called_times(4)
           .always_return({

--- a/spec/plans/standup_cluster_spec.rb
+++ b/spec/plans/standup_cluster_spec.rb
@@ -127,6 +127,7 @@ describe 'plan: standup_cluster' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_plan('facts')
         expect_task('openvox_bootstrap::install')
@@ -137,6 +138,7 @@ describe 'plan: standup_cluster' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('openvox_bootstrap::install')
           .with_targets(['spec-primary-1'])
@@ -146,6 +148,7 @@ describe 'plan: standup_cluster' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('openvox_bootstrap::install')
           .with_targets(['spec-primary-1'])
@@ -155,6 +158,7 @@ describe 'plan: standup_cluster' do
             'collection' => 'openvox8',
             'apt_source' => 'https://apt.voxpupuli.org',
             'yum_source' => 'https://yum.voxpupuli.org',
+            'stop_service' => false,
           })
         expect_task('package')
           .be_called_times(4)

--- a/spec/plans/subplans/install_component_spec.rb
+++ b/spec/plans/subplans/install_component_spec.rb
@@ -33,6 +33,7 @@ describe 'plan: kvm_automation_tooling::subplans::install_component' do
           'collection' => 'openvox8',
           'apt_source' => 'https://apt.voxpupuli.org',
           'yum_source' => 'https://yum.voxpupuli.org',
+          'stop_service' => false,
         }
       )
     expect_task('package')


### PR DESCRIPTION
This is just #44 with a commit to update the specs for the new stop_service param in the openvox_bootstrap install_openvox task.

I should have made that change a couple of months ago with openvox_bootstrap 1.1, but I had forgotten to update the bolt-project.yaml dependency.