### PR TITLE
(tf) Stop installing qemu-guest-agent on vms

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -43,6 +43,7 @@
 * [`download_image`](#download_image): Downloads an image from the given url to a given directory. Requires curl.
 * [`generate_keypair`](#generate_keypair): Generate a passphraseless ssh keypair in a temp directory and return the paths to the keypair files.
 * [`import_libvirt_volume`](#import_libvirt_volume): Imports a local image file as a libvirt volume in the default pool.
+* [`package_init`](#package_init): Assists with some package management initialization steps on newly minted vms.
 * [`resolve_reference`](#resolve_reference): Produce target references for the given role from the given terraform statefile output. (Note this is tightly coupled to the kvm_automation_t
 
 ### Plans
@@ -924,6 +925,26 @@ Data type: `String`
 
 The volume name to attach to the image in libvirt. It will be created in the default pool.
 
+### <a name="package_init"></a>`package_init`
+
+Assists with some package management initialization steps on newly minted vms.
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `refresh_package_cache`
+
+Data type: `Boolean`
+
+Whether to refresh the package cache on the target system.
+
+##### `upgrade_packages`
+
+Data type: `Boolean`
+
+Whether to upgrade all installed packages to their latest versions. (If true, this will also refresh the package cache, regardless of refresh_package_cache value.)
+
 ### <a name="resolve_reference"></a>`resolve_reference`
 
 Produce target references for the given role from the given terraform statefile output. (Note this is tightly coupled to the kvm_automation_tooling terraform vmdomain_details output format.)
@@ -1336,6 +1357,8 @@ The following parameters are available in the `kvm_automation_tooling::standup_c
 * [`user_password`](#-kvm_automation_tooling--standup_cluster--user_password)
 * [`install_openvox`](#-kvm_automation_tooling--standup_cluster--install_openvox)
 * [`install_openvox_params`](#-kvm_automation_tooling--standup_cluster--install_openvox_params)
+* [`refresh_package_cache`](#-kvm_automation_tooling--standup_cluster--refresh_package_cache)
+* [`upgrade_packages`](#-kvm_automation_tooling--standup_cluster--upgrade_packages)
 
 ##### <a name="-kvm_automation_tooling--standup_cluster--cluster_id"></a>`cluster_id`
 
@@ -1568,6 +1591,32 @@ installing something other than the latest agent package from
 the latest collection.
 
 Default value: `{}`
+
+##### <a name="-kvm_automation_tooling--standup_cluster--refresh_package_cache"></a>`refresh_package_cache`
+
+Data type: `Boolean`
+
+Whether to refresh the package cache on
+the vms. For debian vms in particular, running without an apt
+update has been observed to cause package installation failures
+due to stale package lists not having required dependencies or
+servers being removed from the mirrors.
+
+Default value: `true`
+
+##### <a name="-kvm_automation_tooling--standup_cluster--upgrade_packages"></a>`upgrade_packages`
+
+Data type: `Boolean`
+
+Whether to perform a full upgrade of all
+packages on the vms. This can add significant time to the
+installation process and is not done by default. This should
+typically only be necessary if the base images being used are
+significantly out of date, or to ensure latest on the vms for
+security purposes. NOTE: setting this true implies
+refresh_package_cache, regardless of the value of that parameter.
+
+Default value: `false`
 
 ### <a name="kvm_automation_tooling--subplans--install_component"></a>`kvm_automation_tooling::subplans::install_component`
 

--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -10,7 +10,7 @@ modules:
     version_requirement: '>= 9.7 < 10.0.0'
   - name: puppetlabs/package
     version_requirement: '>= 3.1.0 < 4.0.0'
-  - git: https://github.com/jpartlow/puppetlabs-terraform
-    ref: include-module-when-resolving-references
+  - name: puppetlabs/terraform
+    version_requirement: '>= 0.7.2 < 1.0.0'
   - name: puppet/openvox_bootstrap
     version_requirement: '>= 1.4.0 < 2.0.0'

--- a/cloud-init/user-data.yaml.tftpl
+++ b/cloud-init/user-data.yaml.tftpl
@@ -20,19 +20,11 @@ users:
 # https://cloudinit.readthedocs.io/en/latest/reference/modules.html#set-passwords
 # Do not require password change on first login.
 chpasswd: { expire: False }
-# Package Update Upgrade Install Module
-# https://cloudinit.readthedocs.io/en/latest/reference/modules.html#package-update-upgrade-install
-# Ensure qemu agent is installed so that terraform-provider-libvirt can retrieve IP address.
-packages:
-  - qemu-guest-agent
 # https://cloudinit.readthedocs.io/en/latest/reference/modules.html#runcmd
-runcmd:
 %{ if os == "ubuntu" || os == "debian" ~}
+runcmd:
   # Fiddle with systemd-resolved to set the DNS domain since it
   # doesn't seem to pick it up from dhcp.
   - [ sed, -i, -E, -e, 's/ *#?Domains=.*/Domains=${domain_name}/', /etc/systemd/resolved.conf ]
   - [ systemctl, restart, systemd-resolved.service ]
 %{ endif ~}
-  - [ systemctl, daemon-reload ]
-  - [ systemctl, enable, qemu-guest-agent.service ]
-  - [ systemctl, start, --no-block, qemu-guest-agent.service ]

--- a/plans/standup_cluster.pp
+++ b/plans/standup_cluster.pp
@@ -89,6 +89,18 @@
 #   kvm_automation_tooling::install_openvox plan if
 #   installing something other than the latest agent package from
 #   the latest collection.
+# @param refresh_package_cache Whether to refresh the package cache on
+#   the vms. For debian vms in particular, running without an apt
+#   update has been observed to cause package installation failures
+#   due to stale package lists not having required dependencies or
+#   servers being removed from the mirrors.
+# @param upgrade_packages Whether to perform a full upgrade of all
+#   packages on the vms. This can add significant time to the
+#   installation process and is not done by default. This should
+#   typically only be necessary if the base images being used are
+#   significantly out of date, or to ensure latest on the vms for
+#   security purposes. NOTE: setting this true implies
+#   refresh_package_cache, regardless of the value of that parameter.
 plan kvm_automation_tooling::standup_cluster(
   Pattern[/\A[a-zA-Z0-9-]+\Z/] $cluster_id,
   Optional[Kvm_automation_tooling::Operating_system] $os = undef,
@@ -117,6 +129,8 @@ plan kvm_automation_tooling::standup_cluster(
     Optional[install_defaults]      => Kvm_automation_tooling::Openvox_install_params,
   }]
   $install_openvox_params = {},
+  Boolean $refresh_package_cache = true,
+  Boolean $upgrade_packages = false,
 ) {
   $terraform_dir = './terraform'
 
@@ -209,6 +223,12 @@ plan kvm_automation_tooling::standup_cluster(
   $all_targets = $target_map.values().flatten()
 
   wait_until_available($all_targets)
+
+  run_task('kvm_automation_tooling::package_init',
+    $all_targets,
+    'refresh_package_cache' => $refresh_package_cache,
+    'upgrade_packages' => $upgrade_packages,
+  )
 
   if $setup_cluster_ssh {
     $controllers = $target_map.reduce([]) |$acc, $entry| {

--- a/spec/plans/standup_cluster_spec.rb
+++ b/spec/plans/standup_cluster_spec.rb
@@ -110,6 +110,12 @@ describe 'plan: standup_cluster' do
           'return_output' => true,
         )
         .always_return(apply_result)
+      expect_task('kvm_automation_tooling::package_init')
+        .with_targets(['spec-primary-1', 'spec-agent-1'])
+        .with_params({
+          'refresh_package_cache' => true,
+          'upgrade_packages' => false,
+        })
       expect_plan('kvm_automation_tooling::subplans::setup_cluster_ssh')
     end
 

--- a/tasks/package_init.json
+++ b/tasks/package_init.json
@@ -1,0 +1,15 @@
+{
+  "description": "Assists with some package management initialization steps on newly minted vms.",
+  "parameters": {
+    "refresh_package_cache": {
+      "type": "Boolean",
+      "description": "Whether to refresh the package cache on the target system.",
+      "default": true
+    },
+    "upgrade_packages": {
+      "type": "Boolean",
+      "description": "Whether to upgrade all installed packages to their latest versions. (If true, this will also refresh the package cache, regardless of refresh_package_cache value.)",
+      "default": false
+    }
+  }
+}

--- a/tasks/package_init.sh
+++ b/tasks/package_init.sh
@@ -1,0 +1,48 @@
+#! /usr/bin/env bash
+
+set -e
+
+# PT_* variables are set by Bolt.
+# shellcheck disable=SC2154
+refresh_cache="${PT_refresh_package_cache}"
+# shellcheck disable=SC2154
+upgrade_packages="${PT_upgrade_packages}"
+
+# Check if a command exists.
+exists() {
+  command -v "$1" > /dev/null 2>&1
+}
+
+refresh_package_cache() {
+  if exists apt-get; then
+    apt-get update
+  elif exists dnf; then
+    dnf clean all
+    dnf makecache -y
+  elif exists zypper; then
+    zypper refresh
+  else
+    echo "No supported package manager found to refresh cache."
+    exit 1
+  fi
+}
+
+upgrade_all_packages() {
+  if exists apt-get; then
+    apt-get upgrade -y
+  elif exists dnf; then
+    dnf upgrade -y
+  elif exists zypper; then
+    zypper up -y
+  else
+    echo "No supported package manager found to upgrade packages."
+    exit 1
+  fi
+}
+
+if [ "${upgrade_packages}" == 'true' ]; then
+  refresh_package_cache
+  upgrade_all_packages
+elif [ "${refresh_cache}" == 'true' ]; then
+  refresh_package_cache
+fi

--- a/terraform/modules/vm/main.tf
+++ b/terraform/modules/vm/main.tf
@@ -90,23 +90,6 @@ resource "libvirt_domain" "domain" {
   }
 
   devices = {
-    # This is required to allow the qemu agent to work, which is needed
-    # to get the IP address of the machine.
-    # In 0.8 this was implicit when qemu_agent was set to true, but in
-    # 0.9 we need to declare it explicitly.
-    channels = [
-      {
-        source = {
-          unix = {}
-        }
-        target = {
-          virt_io = {
-            name  = "org.qemu.guest_agent.0"
-          }
-        }
-      }
-    ]
-
     consoles = [
       # IMPORTANT: this is a known bug on cloud images, since they
       # expect a console we need to pass it


### PR DESCRIPTION
This was required in the past to get the ip address. But we're succesfully obtaining the ip (faster) from the dhcp lease now, and the background cloud-init using apt-get to get the qemu-guest-agent package is creating a race for apt lock that is interfering when a calling plan does something like immediately install openvox-agent after the vm is up. (this is particularly severe on arm vms, on x86 hosts since they are slower running under qemu)

Since we don't need to the qemu-guest-agent package to get the ip, I'm dropping installing it via cloud-init. If we need it for other utility reasons, it should be installed in a later phase within some controlling Bolt plan.