### PR TITLE
(plans) Calculate wait times based on arch/domain

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,6 +10,7 @@
 
 ### Functions
 
+* [`kvm_automation_tooling::calculate_wait_for_ip_timeout`](#kvm_automation_tooling--calculate_wait_for_ip_timeout): Calculates the timeout for waiting for an IP address to be assigned to a VM.  If any of the VMs are using the qemu domain type or if any of t
 * [`kvm_automation_tooling::fill_vm_spec`](#kvm_automation_tooling--fill_vm_spec): Expand a VM specification hash by filling in defaults from a given Hash.
 * [`kvm_automation_tooling::generate_terraform_vm_spec_set`](#kvm_automation_tooling--generate_terraform_vm_spec_set): Transforms the array of vm specifications received by the plan into a map of terraform objects (hashes) keyed by a unique "$role.$hostname.$p
 * [`kvm_automation_tooling::get_image_url`](#kvm_automation_tooling--get_image_url): Returns the URL of the cloud image for the specified platform.  # NOTES  These are the structure of the URLs for the various platforms as of 
@@ -71,6 +72,60 @@ ATM this is just a placeholder for the module so that rspec-puppet can
 get_module_name and setup the spec/fixtures/modules link correctly.
 
 ## Functions
+
+### <a name="kvm_automation_tooling--calculate_wait_for_ip_timeout"></a>`kvm_automation_tooling::calculate_wait_for_ip_timeout`
+
+Type: Puppet Language
+
+Calculates the timeout for waiting for an IP address to be assigned
+to a VM.
+
+If any of the VMs are using the qemu domain type or if any
+of the VMs have an architecture that does not match the host
+architecture, then the $qemu_timeout value is returned.
+
+Otherwise, the $default_timeout value is returned.
+
+#### `kvm_automation_tooling::calculate_wait_for_ip_timeout(Optional[Kvm_automation_tooling::Os_arch] $host_arch, Array[Kvm_automation_tooling::Vm_spec] $vm_specs, Integer $default_timeout = 300, Integer $qemu_timeout = 900)`
+
+Calculates the timeout for waiting for an IP address to be assigned
+to a VM.
+
+If any of the VMs are using the qemu domain type or if any
+of the VMs have an architecture that does not match the host
+architecture, then the $qemu_timeout value is returned.
+
+Otherwise, the $default_timeout value is returned.
+
+Returns: `Integer` The timeout in seconds for waiting for an IP address to be
+assigned to a VM.
+
+##### `host_arch`
+
+Data type: `Optional[Kvm_automation_tooling::Os_arch]`
+
+The architecture of the host machine.
+
+##### `vm_specs`
+
+Data type: `Array[Kvm_automation_tooling::Vm_spec]`
+
+An array of Vm_spec structs representing the VMs
+being created.
+
+##### `default_timeout`
+
+Data type: `Integer`
+
+The default timeout in seconds to use.
+
+##### `qemu_timeout`
+
+Data type: `Integer`
+
+The timeout in seconds to use if any VMs are
+using the qemu domain type or have an architecture that does not
+match the host architecture.
 
 ### <a name="kvm_automation_tooling--fill_vm_spec"></a>`kvm_automation_tooling::fill_vm_spec`
 
@@ -1658,23 +1713,32 @@ Default value: `false`
 
 ##### <a name="-kvm_automation_tooling--standup_cluster--wait_for_ip_timeout"></a>`wait_for_ip_timeout`
 
-Data type: `Integer`
+Data type: `Optional[Integer]`
 
 The amount of time in seconds to wait for
 the vms to have valid ip addresses assigned after the terraform
-apply before timing out and failing.
+apply before timing out and failing. This is calculated
+automatically based on the vm specs and host architecture, setting
+a higher timeout if any vm is using domain.type qemu or has an
+architecture that does not match the host architecture (which will
+also result in domain.type qemu). But it can be set explicitly
+here. The default for matching arch is 300s and for
+qemu/mismatching arch is 900s.
+(see ./functions/calculate_wait_for_ip_timeout.pp).
 
-Default value: `900`
+Default value: `undef`
 
 ##### <a name="-kvm_automation_tooling--standup_cluster--wait_until_available_timeout"></a>`wait_until_available_timeout`
 
-Data type: `Integer`
+Data type: `Optional[Integer]`
 
 The amount of time in seconds to
 wait for the vms to be available for ssh connections after they have
-ip addresses assigned before timing out and failing.
+ip addresses assigned before timing out and failing. Will mirror
+either the explicitly set or calculated wait_for_ip_timeout unless
+specified here.
 
-Default value: `$wait_for_ip_timeout`
+Default value: `undef`
 
 ##### <a name="-kvm_automation_tooling--standup_cluster--in_gha"></a>`in_gha`
 

--- a/functions/calculate_wait_for_ip_timeout.pp
+++ b/functions/calculate_wait_for_ip_timeout.pp
@@ -1,0 +1,50 @@
+# Calculates the timeout for waiting for an IP address to be assigned
+# to a VM.
+#
+# If any of the VMs are using the qemu domain type or if any
+# of the VMs have an architecture that does not match the host
+# architecture, then the $qemu_timeout value is returned.
+#
+# Otherwise, the $default_timeout value is returned.
+#
+# @param host_arch The architecture of the host machine.
+# @param vm_specs An array of Vm_spec structs representing the VMs
+#   being created.
+# @param default_timeout The default timeout in seconds to use.
+# @param qemu_timeout The timeout in seconds to use if any VMs are
+#   using the qemu domain type or have an architecture that does not
+#   match the host architecture.
+# @return The timeout in seconds for waiting for an IP address to be
+#   assigned to a VM.
+function kvm_automation_tooling::calculate_wait_for_ip_timeout(
+  Optional[Kvm_automation_tooling::Os_arch] $host_arch,
+  Array[Kvm_automation_tooling::Vm_spec] $vm_specs,
+  Integer $default_timeout = 300,
+  Integer $qemu_timeout = 900,
+) >> Integer {
+  $domain_types = $vm_specs.map |$vm_spec| {
+    $vm_spec['domain_type']
+  }.unique()
+  $architectures = $vm_specs.map |$vm_spec| {
+    dig($vm_spec, 'os', 'arch')
+  }.unique()
+  $normalized_host_arch = kvm_automation_tooling::get_normalized_libvirt_arch($host_arch)
+
+  $any_qemu_domains = $domain_types.any |$domain_type| {
+    $domain_type == 'qemu'
+  }
+
+  $any_arch_mismatch = $architectures.any |$arch| {
+    $normalized_arch = kvm_automation_tooling::get_normalized_libvirt_arch($arch)
+    ($normalized_arch =~ Undef) or
+      ($normalized_arch != $normalized_host_arch)
+  }
+
+  if ($any_qemu_domains or $any_arch_mismatch) {
+    $wait_for_ip_timeout = $qemu_timeout
+  } else {
+    $wait_for_ip_timeout = $default_timeout
+  }
+
+  $wait_for_ip_timeout
+}

--- a/plans/standup_cluster.pp
+++ b/plans/standup_cluster.pp
@@ -103,10 +103,19 @@
 #   refresh_package_cache, regardless of the value of that parameter.
 # @param wait_for_ip_timeout The amount of time in seconds to wait for
 #   the vms to have valid ip addresses assigned after the terraform
-#   apply before timing out and failing.
+#   apply before timing out and failing. This is calculated
+#   automatically based on the vm specs and host architecture, setting
+#   a higher timeout if any vm is using domain.type qemu or has an
+#   architecture that does not match the host architecture (which will
+#   also result in domain.type qemu). But it can be set explicitly
+#   here. The default for matching arch is 300s and for
+#   qemu/mismatching arch is 900s.
+#   (see ./functions/calculate_wait_for_ip_timeout.pp).
 # @param wait_until_available_timeout The amount of time in seconds to
 #   wait for the vms to be available for ssh connections after they have
-#   ip addresses assigned before timing out and failing.
+#   ip addresses assigned before timing out and failing. Will mirror
+#   either the explicitly set or calculated wait_for_ip_timeout unless
+#   specified here.
 # @param in_gha Whether this is being run in GitHub Actions. Used
 #   internally for some optimizations. Normally determined
 #   automatically.
@@ -140,8 +149,8 @@ plan kvm_automation_tooling::standup_cluster(
   $install_openvox_params = {},
   Boolean $refresh_package_cache = true,
   Boolean $upgrade_packages = false,
-  Integer $wait_for_ip_timeout = 900,
-  Integer $wait_until_available_timeout = $wait_for_ip_timeout,
+  Optional[Integer] $wait_for_ip_timeout = undef,
+  Optional[Integer] $wait_until_available_timeout = undef,
   Boolean $in_gha = (system::env('GITHUB_ACTIONS') == 'true'),
 ) {
   $terraform_dir = './terraform'
@@ -196,6 +205,11 @@ plan kvm_automation_tooling::standup_cluster(
   out::message("Host architecture: ${host_arch}")
   $tf_vm_specs = kvm_automation_tooling::generate_terraform_vm_spec_set($cluster_id, $vm_specs, $image_results)
   $vm_hostnames = $tf_vm_specs.keys().map |$k| { split($k, '\.')[1] }
+  $calculated_wait_for_ip_timeout = kvm_automation_tooling::calculate_wait_for_ip_timeout($host_arch, $vm_specs)
+  $final_wait_for_ip_timeout =
+    pick($wait_for_ip_timeout, $calculated_wait_for_ip_timeout)
+  $final_wait_until_available_timeout =
+    pick($wait_until_available_timeout, $final_wait_for_ip_timeout)
 
   # Write cluster specific tfvars.json file to a separate directory to
   # keep different cluster instances separated.
@@ -224,7 +238,11 @@ plan kvm_automation_tooling::standup_cluster(
   # the domains. So we have to do a separate refresh after apply to
   # get the assigned ip addresses for the vms before we can proceed.
   $interval = 10
-  $limit = max($wait_for_ip_timeout / $interval, 1)
+  $limit = max($final_wait_for_ip_timeout / $interval, 1)
+  out::message(@("EOS"))
+    Waiting for VMs to have valid IP addresses assigned
+    (timeout: ${final_wait_for_ip_timeout} seconds)...
+    |- EOS
   $valid_ips = ctrl::do_until('limit' => $limit, 'interval' => $interval) || {
     $apply_result = run_plan('terraform::refresh',
       'dir'           => $terraform_dir,
@@ -249,7 +267,7 @@ plan kvm_automation_tooling::standup_cluster(
     out::message("Terraform refresh result: ${refresh_result['stdout']}")
     fail_plan(@("EOS"))
       Timed out waiting for VMs to have valid IP addresses after
-      ${wait_for_ip_timeout} seconds. See above debug output for
+      ${final_wait_for_ip_timeout} seconds. See above debug output for
       libvirt state.
       |- EOS
   }
@@ -273,7 +291,14 @@ plan kvm_automation_tooling::standup_cluster(
 
   $all_targets = $target_map.values().flatten()
 
-  $wait_result = wait_until_available($all_targets, 'wait_time' => $wait_until_available_timeout, '_catch_errors' => true)
+  out::message(@("EOS"))
+    Waiting for VMs to be available for ssh connections
+    (timeout: ${final_wait_until_available_timeout} seconds)...
+    |- EOS
+  $wait_result = wait_until_available($all_targets,
+    'wait_time' => $final_wait_until_available_timeout,
+    '_catch_errors' => true
+  )
   if (!$wait_result.ok()) {
     run_plan('kvm_automation_tooling::subplans::debug_libvirt_state',
       'cluster_id'   => $cluster_id,

--- a/spec/functions/calculate_wait_for_ip_timeout_spec.rb
+++ b/spec/functions/calculate_wait_for_ip_timeout_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+
+describe 'kvm_automation_tooling::calculate_wait_for_ip_timeout' do
+  let(:matching_vms) do
+    [
+      {
+        'role' => 'agent',
+        'os'   => {
+          'name'    => 'ubuntu',
+          'version' => '2204',
+          'arch'    => 'amd64'
+        },
+        'domain_type' => 'kvm'
+      },
+      {
+        'role' => 'agent',
+        'os'   => {
+          'name'    => 'rocky',
+          'version' => '10',
+          'arch'    => 'x86_64'
+        },
+      },
+    ]
+  end
+  let(:non_matching_vms) do
+    [
+      {
+        'role' => 'agent',
+        'os'   => {
+          'name'    => 'ubuntu',
+          'version' => '2204',
+          'arch'    => 'arm64'
+        },
+        'domain_type' => 'kvm',
+      },
+      {
+        'role' => 'agent',
+        'os'   => {
+          'name'    => 'debian',
+          'version' => '13',
+          'arch'    => 'amd64'
+        },
+      },
+    ]
+  end
+  let(:qemu_domain) do
+    [
+      {
+        'role' => 'agent',
+        'os'   => {
+          'name'    => 'ubuntu',
+          'version' => '2204',
+          'arch'    => 'amd64',
+        },
+        'domain_type' => 'qemu',
+      },
+    ]
+  end
+
+  context 'matching arch' do
+    it 'returns the default timeout' do
+      is_expected.to(
+        run.with_params('amd64', matching_vms)
+          .and_return(300)
+      )
+    end
+
+    it 'returns the given default_timeout' do
+      is_expected.to(
+        run.with_params('amd64', matching_vms, 600)
+          .and_return(600)
+      )
+    end
+  end
+
+  context 'non-matching arch' do
+    it 'returns the qemu timeout' do
+      is_expected.to(
+        run.with_params('amd64', non_matching_vms)
+          .and_return(900)
+      )
+      is_expected.to(
+        run.with_params('arm64', matching_vms)
+          .and_return(900)
+      )
+    end
+
+    it 'returns the given qemu_timeout' do
+      is_expected.to(
+        run.with_params('amd64', non_matching_vms, 300, 1200)
+          .and_return(1200)
+      )
+    end
+
+    it 'returns the qemu timeout if host_arch is undef' do
+      is_expected.to(
+        run.with_params(nil, matching_vms)
+          .and_return(900)
+      )
+    end
+
+    it 'returns the qemu timeout if vm spec does not have os' do
+      matching_vms[0].delete('os')
+      is_expected.to(
+        run.with_params('amd64', matching_vms)
+          .and_return(900)
+      )
+    end
+
+  end
+
+  context 'qemu domain' do
+    it 'returns the qemu timeout' do
+      is_expected.to(
+        run.with_params('amd64', qemu_domain)
+          .and_return(900)
+      )
+    end
+  end
+end


### PR DESCRIPTION
There is a significant difference in run times depending on whether any of the vms requires the qemu domain.type. In general, we can default to a timeout of 300s so long as all guest host architectures match and no vm explicitly sets domain_type to 'qemu'. Otherwise 900s is provided as a timeout.

The timeouts to wait for an ip, and to wait for available connections to targets may still be overriden manually with inputs to the standup_cluster plan.