### PR TITLE
(ci) Skip openvox install on ubuntu arm plan_testing workflow

### DIFF
--- a/.github/workflows/plan_testing.yaml
+++ b/.github/workflows/plan_testing.yaml
@@ -92,6 +92,7 @@ jobs:
         run: |-
           jq . <<< $INVENTORY_JSON
       - name: Write Install OpenVox Params
+        if: ${{ matrix.architecture == 'x86_64' }}
         working-directory: kvm_automation_tooling
         env:
           OPENVOX_RELEASED: ${{ matrix.install.released }}
@@ -124,12 +125,13 @@ jobs:
           cat install_openvox_params.json
       - name: Run install_openvox plan
         working-directory: kvm_automation_tooling
+        if: ${{ matrix.architecture == 'x86_64' }}
         run: |-
           bundle exec bolt plan run kvm_automation_tooling::install_openvox \
             --inventory terraform/instances/inventory.test.yaml \
             --params=@install_openvox_params.json
       - name: Validate versions
-        if: ${{ matrix.install.released == false }}
+        if: ${{ (matrix.install.released == false) && (matrix.architecture == 'x86_64') }}
         env:
           OPENVOX_AGENT_VERSION: ${{ matrix.install.agent-version }}
           OPENVOX_SERVER_VERSION: ${{ matrix.install.server-version }}
@@ -145,7 +147,7 @@ jobs:
           jq -e '."test-primary-1"."openvoxdb" | test("^'${OPENVOX_DB_VERSION//./\\\\.}'-")' /tmp/openvox_versions.test.json
           jq -e '."test-primary-1"."openvoxdb-termini" | test("^'${OPENVOX_DB_VERSION//./\\\\.}'-")' /tmp/openvox_versions.test.json
       - name: Validate packages
-        if: ${{ matrix.install.released == true }}
+        if: ${{ (matrix.install.released == true) && (matrix.architecture == 'x86_64') }}
         env:
           OPENVOX_AGENT_VERSION: ${{ matrix.install.agent-version }}
           OPENVOX_SERVER_VERSION: ${{ matrix.install.server-version }}


### PR DESCRIPTION
The ubuntu arm vms are the slowest of the lot, the Ubuntu 26.04 vms in particular taking up to an hour and half to complete. I still want to check that the module can spin up arm vms of the ubuntu os, but there's no real purpose to validating installation of openvox packages on arm on these platforms, not for the amount of time it's costing.